### PR TITLE
[19738] Unchecks bicycle and motorbike when checking wheelchair access

### DIFF
--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresults/TripResultListViewModel.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresults/TripResultListViewModel.kt
@@ -200,16 +200,20 @@ class TripResultListViewModel @Inject constructor(
             .map {
                 it.clicked
                     .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe {
+                    .subscribe { type ->
                         // The transportVisibilityFilter will save walking vs wheelchair automatically,
                         // but we need to manually fix the display, as walking and wheelchair are mutually exclusive.
-                        if (it.first == TransportMode.ID_WALK) {
+                        if (type.first == TransportMode.ID_WALK) {
                             toggleTransportModeChecked(TransportMode.ID_WHEEL_CHAIR, false)
-                        } else if (it.first == TransportMode.ID_WHEEL_CHAIR) {
+                        } else if (type.first == TransportMode.ID_WHEEL_CHAIR) {
                             toggleTransportModeChecked(TransportMode.ID_WALK, false)
+                            if (!type.second) {
+                                toggleTransportModeChecked(TransportMode.ID_BICYCLE, true)
+                                toggleTransportModeChecked(TransportMode.ID_MOTORBIKE, true)
+                            }
                         }
 
-                        transportVisibilityFilter!!.setSelected(it.first, it.second)
+                        transportVisibilityFilter!!.setSelected(type.first, type.second)
                         reload()
                     }.autoClear()
                 it


### PR DESCRIPTION
## Update: Transport Mode Selection Logic Refinement

### Files Modified
- `TripResultListViewModel.kt`

### Changes Summary

#### Mutual Exclusivity Fix
- Adjusted the logic to ensure walking and wheelchair modes are mutually exclusive.
- Manual display fixes implemented to accurately represent state changes when toggling between these modes.

#### Transport Mode Checking Enhancement
- Enhanced the selection logic to properly handle multiple transport modes.
- Secondary transport modes like bicycle or motorbike are now correctly toggled in conjunction with primary modes.

### Purpose of Changes
- The modifications refine the selection mechanism for transport modes within the app, correcting the mutual exclusivity between walking and wheelchair options.
- The update provides a more intuitive and accurate selection process for users, accommodating various transport preferences seamlessly.

### Testing Instructions
- Test the exclusivity between walking and wheelchair modes to ensure toggling one mode off when the other is selected.
- Confirm that activating a secondary mode like bicycle or motorbike does not improperly affect the primary transport mode selections.
- Verify that the user interface updates to reflect these selections correctly and without error.
