### PR TITLE
[20331] TimetableFragment's TimetableEntry item click logic fix 

### DIFF
--- a/TripKitAndroidUI/build.gradle
+++ b/TripKitAndroidUI/build.gradle
@@ -10,6 +10,11 @@ repositories {
 }
 android {
     compileSdkVersion versions.compileSdkVersion
+
+    androidExtensions {
+        experimental = true
+    }
+
     defaultConfig {
         minSdkVersion versions.proMinSdkVersion
         targetSdkVersion versions.targetSdkVersion
@@ -21,6 +26,11 @@ android {
                 arguments += ["room.schemaLocation": "$projectDir/schemas".toString()]
             }
         }
+
+        // This flag is implemented to maintain backwards compatibility following code cleanup.
+        // It should be utilized in validation processes to support both new and old coding approaches,
+        // ensuring that SDK users employing older methodologies will continue to experience seamless functionality.
+        buildConfigField 'int', 'TRIPKIT_UI_VERSION', "${tripkitUiVersion}"
     }
 
     packagingOptions {

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/controller/homeviewcontroller/TKUIHomeViewControllerViewModel.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/controller/homeviewcontroller/TKUIHomeViewControllerViewModel.kt
@@ -1,29 +1,59 @@
 package com.skedgo.tripkit.ui.controller.homeviewcontroller
 
+import android.annotation.SuppressLint
+import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import com.skedgo.rxtry.Failure
+import com.skedgo.rxtry.Success
+import com.skedgo.rxtry.Try
+import com.skedgo.rxtry.toTry
+import com.skedgo.tripkit.common.model.Location
+import com.skedgo.tripkit.location.GeoPoint
+import com.skedgo.tripkit.location.UserGeoPointRepository
+import com.skedgo.tripkit.ui.R
 import com.skedgo.tripkit.ui.core.RxViewModel
+import io.reactivex.schedulers.Schedulers
+import timber.log.Timber
+import javax.inject.Inject
 
-class TKUIHomeViewControllerViewModel : RxViewModel() {
+@SuppressLint("StaticFieldLeak")
+class TKUIHomeViewControllerViewModel @Inject constructor(
+    private val context: Context,
+    userGeoPointRepository: UserGeoPointRepository
+) : RxViewModel() {
 
     private val _state = MutableLiveData(TKUIHomeViewControllerUIState())
     val state: LiveData<TKUIHomeViewControllerUIState> = _state
 
-    private val _centerPinVisible = MutableLiveData(false)
-    val centerPinVisible: LiveData<Boolean> = _centerPinVisible
-
-    private val _locationPointerFrameVisible = MutableLiveData(false)
-    val locationPointerFrameVisible: LiveData<Boolean> = _locationPointerFrameVisible
-
     private val _myLocationButtonVisible = MutableLiveData(false)
     val myLocationButtonVisible: LiveData<Boolean> = _myLocationButtonVisible
 
-    fun setCenterPinVisible(isVisible: Boolean) {
-        _centerPinVisible.postValue(isVisible)
-    }
+    private val userGeoPointObservable =
+        userGeoPointRepository.getFirstCurrentGeoPoint()
+            .toTry()
+            .map<Try<Location>> { tried: Try<GeoPoint> ->
+                when (tried) {
+                    is Success -> {
+                        val location =
+                            Location(tried.invoke().latitude, tried.invoke().longitude).also {
+                                it.name = context.resources.getString(R.string.current_location)
+                            }
+                        Success(location)
+                    }
 
-    fun setLocationPointerFrameVisible(isVisible: Boolean) {
-        _locationPointerFrameVisible.postValue(isVisible)
+                    is Failure -> Failure<Location>(tried())
+                }
+            }.subscribeOn(Schedulers.io())
+
+    fun getUserGeoPoint(location: (Try<Location>) -> Unit) {
+        userGeoPointObservable.subscribe(
+            {
+                location.invoke(it)
+            }, {
+                Timber.e(it)
+            }
+        ).autoClear()
     }
 
     fun setMyLocationButtonVisible(isVisible: Boolean) {

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/core/module/ViewModelModule.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/core/module/ViewModelModule.kt
@@ -2,6 +2,7 @@ package com.skedgo.tripkit.ui.core.module
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.skedgo.tripkit.ui.controller.homeviewcontroller.TKUIHomeViewControllerViewModel
 import com.skedgo.tripkit.ui.routing.autocompleter.RouteAutocompleteViewModel
 import com.skedgo.tripkit.ui.trippreview.TripPreviewPagerViewModel
 import dagger.Binds
@@ -25,4 +26,9 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(TripPreviewPagerViewModel::class)
     internal abstract fun bindTripPreviewPagerViewModel(viewModel: TripPreviewPagerViewModel): ViewModel
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(TKUIHomeViewControllerViewModel::class)
+    internal abstract fun bindTKUIHomeViewControllerViewModel(viewModel: TKUIHomeViewControllerViewModel): ViewModel
 }

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/favorites/trips/Waypoint.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/favorites/trips/Waypoint.kt
@@ -1,17 +1,66 @@
 package com.skedgo.tripkit.ui.favorites.trips
 
+import com.skedgo.tripkit.routing.TripSegment
+import com.skedgo.tripkit.ui.model.TimetableEntry
+import timber.log.Timber
+
 data class Waypoint(
-        val lat: Double? = 0.0,
-        val lng: Double? = 0.0,
-        val mode: String?,
-        val modeTitle: String? = null,
-        val time: Long = 0,
-        val start: String? = null,
-        val end: String? = null,
-        val startTime: String? = null,
-        val endTime: String? = null,
-        val serviceTripId: String? = null,
-        val operator: String? = null,
-        val region: String? = null,
-        val disembarkationRegion: String? = null,
-        val vehicleUUID: String? = null)
+    val lat: Double? = 0.0,
+    val lng: Double? = 0.0,
+    val mode: String?,
+    val modeTitle: String? = null,
+    val time: Long = 0,
+    val start: String? = null,
+    val end: String? = null,
+    val startTime: String? = null,
+    val endTime: String? = null,
+    val serviceTripId: String? = null,
+    val operator: String? = null,
+    val region: String? = null,
+    val disembarkationRegion: String? = null,
+    val vehicleUUID: String? = null
+) {
+    companion object {
+        fun parseFromTimetableEntryAndSegment(segment: TripSegment, entry: TimetableEntry): Waypoint {
+            var endTime = entry.endTimeInSecs
+            if (endTime <= 0) {
+                val toAdd = segment.endTimeInSecs - segment.startTimeInSecs
+                endTime = entry.serviceTime + toAdd
+            }
+            return Waypoint(
+                mode = entry.modeInfo?.id,
+                start = entry.stopCode ?: segment.startStopCode,
+                end = entry.endStopCode ?: segment.endStopCode,
+                startTime = entry.serviceTime.toString(),
+                endTime = endTime.toString(),
+                serviceTripId = entry.serviceTripId,
+                operator = entry.operator,
+                region = segment.from.region,
+                disembarkationRegion = segment.to.region
+            )
+        }
+
+        fun parseFromSegment(segment: TripSegment): Waypoint? {
+            try {
+                val mode = segment.getModeForWayPoint()
+                var vehicleUUID: String? = null
+                segment.realTimeVehicle?.id?.let {
+                    vehicleUUID = it.toString()
+                }
+
+                return mode.first?.let {
+                    Waypoint(
+                        start = segment.from.coordinateString,
+                        end = segment.to.coordinateString,
+                        mode = it,
+                        vehicleUUID = vehicleUUID
+                    )
+                }
+            } catch (e: Exception) {
+                Timber.e(e)
+            }
+
+            return null
+        }
+    }
+}

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/trippreview/TripPreviewPagerListener.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/trippreview/TripPreviewPagerListener.kt
@@ -9,10 +9,18 @@ import kotlinx.coroutines.CoroutineScope
 
 interface TripPreviewPagerListener {
     fun onServiceActionButtonClicked(_tripSegment: TripSegment?, action: String?)
+
+    @Deprecated("Keep the logic on the [TimetableFragment] and use [viewTimetableEntry] instead")
     fun onTimetableEntryClicked(
         segment: TripSegment?,
         scope: CoroutineScope,
         entry: TimetableEntry
+    )
+
+    fun viewTimetableEntry(
+        tripGroup: TripGroup,
+        trip: Trip,
+        segment: TripSegment
     )
 
     fun reportPlannedTrip(trip: Trip?, tripGroups: List<TripGroup>)
@@ -25,4 +33,5 @@ interface TripPreviewPagerListener {
     fun onToggleBottomSheetDrag(isDraggable: Boolean)
     fun getCurrentPagerItemType(): Int
     fun getLatestTrip(): Trip?
+    fun showUpdateLoader(show: Boolean, message: String)
 }

--- a/TripKitAndroidUI/src/main/res/values/iOS.xliff.xml
+++ b/TripKitAndroidUI/src/main/res/values/iOS.xliff.xml
@@ -1517,5 +1517,6 @@ Note, your iCloud data will not be deleted by this, but you can delete this in t
 	<string name="bookings">Bookings</string>
 	<string name="impaired">Impaired</string>
 	<string name="next_up">Next Up</string>
+	<string name="could_not_get_location">Could not get location</string>
 </resources>
 	<!-- This is an auto generated file (Mon Jan 20 14:50:01 CET 2020) -->

--- a/variables.gradle
+++ b/variables.gradle
@@ -5,4 +5,5 @@ ext {
     publishMavenUrl = "https://www.myget.org/F/skedgo/maven"
     publishMavenUsername = "skedgo"
     publishMavenToken = "9b1742e0-6370-45bc-b0b5-0348b01031c2"
+    tripkitUiVersion = 2
 }


### PR DESCRIPTION
- Update TimetableFragment and TimetableViewModel to handle TimetableEntry item click logic to TimetableViewModel itself and avoid doing it to the parent fragment using TripPreviewPagerListener.onTimetableEntryClicked.
- Introduced TRIPKIT_UI_VERSION buildConfigField for backwards compatibility flag in order to have a refactored version but still able to support the old approach that's being used by the old SDK users, e.g. TripGo.
- Moved logic, data fetching from repositories to viewModel on TKUIHomeViewControllerFragment