### PR TITLE
[19947] Add Crowdiness on trip segment if realtimeVehicle is available [20385] Duplicate RoadTag fix [20406] Scrolling conflict fix

### DIFF
--- a/TripKitAndroidUI/build.gradle
+++ b/TripKitAndroidUI/build.gradle
@@ -197,6 +197,8 @@ dependencies {
     testImplementation libs.kluent
     testImplementation libs.androidxTesting
     testImplementation libs.assertjCore
+    testImplementation libs.coroutinesTest
+    testImplementation libs.bindingCollectionAdapter
 }
 
 group = tripkitGroup

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/trippreview/segment/TripSegmentSummary.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/trippreview/segment/TripSegmentSummary.kt
@@ -15,4 +15,10 @@ data class TripSegmentSummary(
     val description: String? = null,
     val modeId: String? = null,
     val isHideExactTimes: Boolean = false
-)
+) {
+    fun getSummaryItem(): TripSegmentSummaryItemViewModel {
+        return TripSegmentSummaryItemViewModel.parseFromTripSegmentSummary(
+            this, false
+        )
+    }
+}

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripSegmentItemViewModel.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripSegmentItemViewModel.kt
@@ -13,6 +13,7 @@ import android.text.style.ForegroundColorSpan
 import android.text.style.StrikethroughSpan
 import android.text.style.StyleSpan
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.databinding.ObservableBoolean
 import androidx.databinding.ObservableField
@@ -33,6 +34,7 @@ import com.skedgo.tripkit.ui.R
 import com.skedgo.tripkit.ui.TripKitUI
 import com.skedgo.tripkit.ui.core.RxViewModel
 import com.skedgo.tripkit.ui.core.fetchAsync
+import com.skedgo.tripkit.ui.trip.details.viewmodel.OccupancyViewModel
 import com.skedgo.tripkit.ui.tripresults.GetTransportIconTintStrategy
 import com.skedgo.tripkit.ui.tripresults.TripSegmentHelper
 import com.skedgo.tripkit.ui.utils.*
@@ -47,7 +49,8 @@ class TripSegmentItemViewModel @Inject internal constructor(
     private val context: Context,
     private val getTransportIconTintStrategy: GetTransportIconTintStrategy,
     private val tripSegmentHelper: TripSegmentHelper,
-    private val printTime: PrintTime
+    private val printTime: PrintTime,
+    val occupancyViewModel: OccupancyViewModel
 ) : RxViewModel() {
     enum class SegmentViewType {
         TERMINAL,
@@ -62,7 +65,6 @@ class TripSegmentItemViewModel @Inject internal constructor(
     val showStartTime = ObservableBoolean(false)
     val endTime = ObservableField<SpannableString>()
     val showEndTime = ObservableBoolean(false)
-    val startTimeColor = ObservableField<Int>(ContextCompat.getColor(context, R.color.black1))
 
     val description = ObservableField<String>()
     val showDescription = ObservableBoolean(false)
@@ -273,7 +275,13 @@ class TripSegmentItemViewModel @Inject internal constructor(
             }
 
             _isHideExactTimes.value = it.isHideExactTimes //it.trip.isHideExactTimes
+            initOccupancy(it)
         }
+    }
+
+    @VisibleForTesting
+    fun initOccupancy(tripSegment: TripSegment) {
+        tripSegment.realTimeVehicle?.let { occupancyViewModel.setOccupancy(it, false) }
     }
 
     fun generateRoadTags() {

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripSegmentItemViewModel.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripSegmentItemViewModel.kt
@@ -97,6 +97,8 @@ class TripSegmentItemViewModel @Inject internal constructor(
     private val _roadTagsCharItems = MutableLiveData<List<RoadTagChartItem>>()
     val roadTagChartItems: LiveData<List<RoadTagChartItem>> = _roadTagsCharItems
 
+    private var isStationaryItem = false
+
     //TODO break this big function into small functions
     fun setupSegment(
         viewType: SegmentViewType,
@@ -108,9 +110,11 @@ class TripSegmentItemViewModel @Inject internal constructor(
         hasRealtime: Boolean = false,
         lineColor: Int = Color.TRANSPARENT,
         topConnectionColor: Int = lineColor,
-        bottomConnectionColor: Int = lineColor
+        bottomConnectionColor: Int = lineColor,
+        isStationaryItem: Boolean = false
     ) {
         var tintWhite = false
+        this.isStationaryItem = isStationaryItem
         tripSegment?.let {
             this.title.set(title)
 
@@ -275,7 +279,9 @@ class TripSegmentItemViewModel @Inject internal constructor(
             }
 
             _isHideExactTimes.value = it.isHideExactTimes //it.trip.isHideExactTimes
-            initOccupancy(it)
+            if(!isStationaryItem) {
+                initOccupancy(it)
+            }
         }
     }
 
@@ -285,6 +291,7 @@ class TripSegmentItemViewModel @Inject internal constructor(
     }
 
     fun generateRoadTags() {
+        if(isStationaryItem) return
         val roadTagChartItems = mutableListOf<RoadTagChartItem>()
         tripSegment?.streets?.filter { !it.roadTags().isNullOrEmpty() }
             ?.flatMap { street ->

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripSegmentsViewModel.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripSegmentsViewModel.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
+import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.databinding.ObservableArrayList
 import androidx.databinding.ObservableBoolean
@@ -83,24 +84,35 @@ class TripSegmentsViewModel @Inject internal constructor(
 
     private val segmentViewModels: MutableList<TripSegmentItemViewModel> = ArrayList()
     val buttons = ObservableArrayList<ActionButtonViewModel>()
-    val buttonsBinding =
+    val buttonsBinding: ItemBinding<ActionButtonViewModel> by lazy {
         ItemBinding.of<ActionButtonViewModel>(BR.viewModel, R.layout.trip_segment_action_button)
             .bindExtra(BR.listener, this)
+    }
+
     val itemViewModels = ObservableField(emptyList<Any>())
-    val itemBinding = ItemBinding.of(
-        OnItemBindClass<Any>()
-            .map(
-                CreditSourcesOfDataViewModel::class.java,
-                BR.viewModel,
-                R.layout.credit_sources_of_data
-            )
-            .map(TripSegmentItemViewModel::class.java, BR.viewModel, R.layout.trip_segment)
-            .map(
-                TripSegmentGetOffAlertsViewModel::class.java,
-                BR.viewModel,
-                R.layout.trip_segment_get_off_alert
-            )
-    )
+
+    /**
+     * Getting error on unit test when initializing viewModel class with BR for
+     * me.tatarka.bindingcollectionadapter2.ItemBinding, so updated the implementation to
+     * use lazy to not execute me.tatarka.bindingcollectionadapter2.ItemBinding on viewModel
+     * initialization
+     */
+    val itemBinding: ItemBinding<Any> by lazy {
+        ItemBinding.of(
+            OnItemBindClass<Any>()
+                .map(
+                    CreditSourcesOfDataViewModel::class.java,
+                    BR.viewModel,
+                    R.layout.credit_sources_of_data
+                )
+                .map(TripSegmentItemViewModel::class.java, BR.viewModel, R.layout.trip_segment)
+                .map(
+                    TripSegmentGetOffAlertsViewModel::class.java,
+                    BR.viewModel,
+                    R.layout.trip_segment_get_off_alert
+                )
+        )
+    }
     val showCloseButton = ObservableBoolean(false)
     val isHideExactTimes = ObservableBoolean(false)
 
@@ -151,10 +163,12 @@ class TripSegmentsViewModel @Inject internal constructor(
     private val tripSummaryStream = MutableSharedFlow<List<TripSegmentSummaryItemViewModel>>()
 
     val summaryItems: ObservableArrayList<TripSegmentSummaryItemViewModel> = ObservableArrayList()
-    val summaryItemsBinding = ItemBinding.of<TripSegmentSummaryItemViewModel>(
-        BR.viewModel,
-        R.layout.item_trip_segment_summary
-    )
+    val summaryItemsBinding: ItemBinding<TripSegmentSummaryItemViewModel> by lazy {
+        ItemBinding.of<TripSegmentSummaryItemViewModel>(
+            BR.viewModel,
+            R.layout.item_trip_segment_summary
+        )
+    }
 
     init {
         tripSummaryStream
@@ -571,7 +585,8 @@ class TripSegmentsViewModel @Inject internal constructor(
         itemViewModels.set(newItems)
     }
 
-    private fun generateSummaryItems(segments: List<TripSegment>) {
+    @VisibleForTesting
+    fun generateSummaryItems(segments: List<TripSegment>) {
         val tripSegmentSummaryItem =
             mutableListOf<TripSegmentSummaryItemViewModel>()
         segments.forEach { segment ->

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/utils/TripSegmentUIExtension.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/utils/TripSegmentUIExtension.kt
@@ -9,7 +9,10 @@ import androidx.core.content.ContextCompat
 import com.google.android.gms.common.util.CollectionUtils
 import com.skedgo.tripkit.common.model.RealtimeAlert
 import com.skedgo.tripkit.common.model.TransportMode
+import com.skedgo.tripkit.common.util.TimeUtils
 import com.skedgo.tripkit.common.util.TransportModeUtils
+import com.skedgo.tripkit.datetime.PrintTime
+import com.skedgo.tripkit.routing.Trip
 import com.skedgo.tripkit.routing.TripSegment
 import com.skedgo.tripkit.routing.endDateTime
 import com.skedgo.tripkit.routing.startDateTime
@@ -102,6 +105,7 @@ fun TripSegment.generateTripPreviewHeader(icon: Drawable): TripSegmentSummary {
     return TripSegmentSummary(
         id = this.id,
         title = this.getTitle(),
+        subTitle = this.endDateTime.toString(dateTimeFormatter),
         icon = icon,
         description = "${
             this.trip.startDateTime.toString(
@@ -111,6 +115,72 @@ fun TripSegment.generateTripPreviewHeader(icon: Drawable): TripSegmentSummary {
         modeId = this.transportModeId,
         isHideExactTimes = this.isHideExactTimes
     )
+}
+
+fun TripSegment.generateTripPreviewHeader(
+    context: Context,
+    icon: Drawable,
+    printTime: PrintTime
+): TripSegmentSummary {
+    val dateTimeFormatter = DateTimeFormat.forPattern("hh:mm a")
+    return TripSegmentSummary(
+        id = this.id,
+        title = this.getTitle(),
+        subTitle = this.getSubtitle(context, this.trip, printTime),
+        icon = icon,
+        description = "${
+            this.trip.startDateTime.toString(
+                dateTimeFormatter
+            )
+        } - ${this.trip.endDateTime.toString(dateTimeFormatter)}",
+        modeId = this.transportModeId,
+        isHideExactTimes = this.isHideExactTimes
+    )
+}
+
+private fun TripSegment.getSubtitle(context: Context, trip: Trip, printTime: PrintTime): String? {
+    when {
+        this.isRealTime -> {
+            return if (this.hasTimeTable()) {
+                if (this.frequency == 0) {
+                    printTime.printLocalTime(this.startDateTime.toLocalTime())
+                } else {
+                    context.resources.getString(R.string.real_minustime)
+                }
+            } else {
+                context.resources.getString(R.string.live_traffic)
+            }
+        }
+
+        trip.isMixedModal(false) && !this.hasTimeTable() -> {
+            return TimeUtils.getDurationInHoursMins(
+                context,
+                (this.endTimeInSecs - this.startTimeInSecs).toInt()
+            )
+        }
+
+        this.metresSafe > 0 -> {
+            if (this.isCycling) {
+                return context.resources.getString(
+                    R.string._pattern_cycle_friendly,
+                    "${this.cycleFriendliness}%"
+                )
+            } else if (this.isWheelchair) {
+                return context.resources.getString(
+                    R.string._pattern_wheelchair_friendly,
+                    "${this.wheelchairFriendliness}%"
+                )
+            }
+        }
+
+        this.hasTimeTable() -> {
+            if (this.frequency == 0) {
+                return printTime.printLocalTime(this.startDateTime.toLocalTime())
+            }
+        }
+    }
+
+    return null
 }
 
 private fun TripSegment.getTitle(): String {

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/views/CustomViewPager.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/views/CustomViewPager.kt
@@ -1,0 +1,37 @@
+package com.skedgo.tripkit.ui.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import androidx.viewpager.widget.ViewPager
+
+/**
+ * To handle BottomSheet and Recyclerview touch and scroll issues with ViewPager
+ */
+class CustomViewPager(context: Context, attrs: AttributeSet) : ViewPager(context, attrs) {
+    private var initialXValue: Float = 0f
+    private var initialYValue: Float = 0f
+    private val threshold = 50
+
+    override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+        when (ev.action) {
+            MotionEvent.ACTION_DOWN -> {
+                initialXValue = ev.x
+                initialYValue = ev.y
+                parent.requestDisallowInterceptTouchEvent(true)
+            }
+            MotionEvent.ACTION_MOVE -> {
+                val diffX = Math.abs(ev.x - initialXValue)
+                val diffY = Math.abs(ev.y - initialYValue)
+                if (diffX > threshold && diffX > diffY) {
+                    // Horizontal scroll, ViewPager should handle it
+                    parent.requestDisallowInterceptTouchEvent(true)
+                } else if (diffY > threshold && diffY > diffX) {
+                    // Vertical scroll, let the parent (BottomSheet) handle it
+                    parent.requestDisallowInterceptTouchEvent(false)
+                }
+            }
+        }
+        return super.onInterceptTouchEvent(ev)
+    }
+}

--- a/TripKitAndroidUI/src/main/res/layout/item_fake_graph.xml
+++ b/TripKitAndroidUI/src/main/res/layout/item_fake_graph.xml
@@ -51,7 +51,8 @@
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:layout_marginTop="@dimen/spacing_small"
-            android:background="@color/black"
+            android:layout_marginStart="@dimen/spacing_small"
+            android:background="@color/black4"
             app:layout_constraintTop_toBottomOf="@+id/tvMax" />
 
         <androidx.recyclerview.widget.RecyclerView

--- a/TripKitAndroidUI/src/main/res/layout/layout_road_tags.xml
+++ b/TripKitAndroidUI/src/main/res/layout/layout_road_tags.xml
@@ -26,6 +26,16 @@
             tools:listitem="@layout/item_fake_graph"
             tools:itemCount="1"/>
 
+        <View
+            android:id="@+id/divider"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/divider_size"
+            android:layout_marginTop="@dimen/spacing_small"
+            android:background="@color/black4"
+            app:layout_constraintTop_toBottomOf="@+id/rvRoadTagsChart"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>

--- a/TripKitAndroidUI/src/main/res/layout/trip_result_pager.xml
+++ b/TripKitAndroidUI/src/main/res/layout/trip_result_pager.xml
@@ -13,7 +13,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-        <androidx.viewpager.widget.ViewPager
+        <com.skedgo.tripkit.ui.views.CustomViewPager
                 android:id="@+id/tripGroupsPager"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/TripKitAndroidUI/src/main/res/layout/trip_segment.xml
+++ b/TripKitAndroidUI/src/main/res/layout/trip_segment.xml
@@ -112,6 +112,33 @@
                 android:textDirection="locale"
                 tools:text="Some Direction" />
 
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="@{viewModel.occupancyViewModel.hasInformation()}">
+
+                <ImageView
+                    android:id="@+id/occupancyView"
+                    android:layout_width="wrap_content"
+                    android:layout_height="@dimen/icon_regular"
+                    android:src="@{viewModel.occupancyViewModel.drawableLeft}"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:src="@drawable/ic_occupancy_50" />
+
+                <TextView
+                    style="@style/TextAppearance.MaterialComponents.Caption"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/spacing_small"
+                    android:text="@{viewModel.occupancyViewModel.occupancyText}"
+                    app:layout_constraintBottom_toBottomOf="@id/occupancyView"
+                    app:layout_constraintStart_toEndOf="@+id/occupancyView"
+                    app:layout_constraintTop_toTopOf="@id/occupancyView"
+                    tools:text="Empty"/>
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
             <TextView
                 android:id="@+id/description"
                 style="@style/TextAppearance.MaterialComponents.Caption"
@@ -186,7 +213,7 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/spacing_normal"
             android:text="@{viewModel.startTime}"
-            android:textColor="@{viewModel.startTimeColor}"
+            android:textColor="@color/black1"
             android:visibility="@{viewModel.showStartTime &amp;&amp; !viewModel.isHideExactTimes()}"
             app:layout_constraintBottom_toBottomOf="@+id/content"
             app:layout_constraintEnd_toEndOf="parent"

--- a/TripKitAndroidUI/src/main/res/layout/trip_segment_list_fragment.xml
+++ b/TripKitAndroidUI/src/main/res/layout/trip_segment_list_fragment.xml
@@ -61,6 +61,24 @@
             app:layout_constraintTop_toBottomOf="@+id/duration" />
 
         <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/layoutTripSummary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:visibility="visible"
+            android:nestedScrollingEnabled="false"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/arrive"
+            app:itemBinding="@{viewModel.summaryItemsBinding}"
+            app:items="@{viewModel.summaryItems}"
+            tools:itemCount="2"
+            tools:layout="@layout/fragment_trip_preview_header"
+            tools:listitem="@layout/item_trip_segment_summary"
+            tools:visibility="visible" />
+
+        <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/buttonLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -71,7 +89,9 @@
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/arrive" />
+            app:layout_constraintTop_toBottomOf="@+id/layoutTripSummary"
+            tools:listitem="@layout/trip_segment_action_button"
+            tools:itemCount="2"/>
 
         <View
             android:id="@+id/divider"

--- a/TripKitAndroidUI/src/test/java/com/skedgo/tripkit/ui/base/TripSegmentMock.kt
+++ b/TripKitAndroidUI/src/test/java/com/skedgo/tripkit/ui/base/TripSegmentMock.kt
@@ -1,0 +1,43 @@
+package com.skedgo.tripkit.ui.base
+
+import com.skedgo.tripkit.routing.ModeInfo
+import com.skedgo.tripkit.routing.SegmentType
+import com.skedgo.tripkit.routing.ServiceColor
+import com.skedgo.tripkit.routing.TripSegment
+
+class TripSegmentMock {
+
+    companion object {
+
+        val tripSegmentScheduled = TripSegment().apply {
+            type = SegmentType.SCHEDULED
+            modeInfo = createModeInfo()
+        }
+
+        val tripSegmentArrival = TripSegment().apply {
+            type = SegmentType.ARRIVAL
+            modeInfo = createModeInfo()
+        }
+
+        val tripSegmentDeparture = TripSegment().apply {
+            type = SegmentType.DEPARTURE
+            modeInfo = createModeInfo()
+        }
+
+        fun getTripSegments(): List<TripSegment> =
+            listOf(tripSegmentScheduled, tripSegmentArrival, tripSegmentDeparture)
+
+        fun createModeInfo(): ModeInfo =
+            ModeInfo().apply {
+                alternativeText = "Taxi"
+                localIconName = "taxi"
+                remoteIconName = "taxi"
+                remoteDarkIconName = "taxi"
+                description = "Taxi"
+                id = "ps_tax"
+                color = ServiceColor(22, 33, 44)
+            }
+
+    }
+
+}

--- a/TripKitAndroidUI/src/test/java/com/skedgo/tripkit/ui/tripresult/TripSegmentItemViewModelTest.kt
+++ b/TripKitAndroidUI/src/test/java/com/skedgo/tripkit/ui/tripresult/TripSegmentItemViewModelTest.kt
@@ -1,0 +1,96 @@
+package com.skedgo.tripkit.ui.tripresult
+
+import android.content.Context
+import android.content.res.Resources
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.core.content.ContextCompat
+import com.skedgo.tripkit.datetime.PrintTime
+import com.skedgo.tripkit.routing.Occupancy
+import com.skedgo.tripkit.routing.RealTimeVehicle
+import com.skedgo.tripkit.routing.TripSegment
+import com.skedgo.tripkit.ui.R
+import com.skedgo.tripkit.ui.base.MockKTest
+import com.skedgo.tripkit.ui.trip.details.viewmodel.OccupancyViewModel
+import com.skedgo.tripkit.ui.tripresults.GetTransportIconTintStrategy
+import com.skedgo.tripkit.ui.tripresults.TripSegmentHelper
+import io.mockk.MockKAnnotations
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class TripSegmentItemViewModelTest: MockKTest() {
+
+    private lateinit var context: Context
+
+    @MockK
+    private lateinit var occupancyViewModel: OccupancyViewModel
+
+    @MockK
+    private lateinit var getTransportIconTintStrategy: GetTransportIconTintStrategy
+
+    @MockK
+    private lateinit var tripSegmentHelper: TripSegmentHelper
+
+    @MockK
+    private lateinit var printTime: PrintTime
+
+    private lateinit var viewModel: TripSegmentItemViewModel
+
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    private val mockTripSegment = mockk<TripSegment>(relaxed = true)
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+
+        val mockResources = mockk<Resources>().apply {
+            every { getColor(any()) } returns mockk()
+        }
+
+        context = mockk<Context>().apply {
+            every { resources } returns mockResources
+            every { getColor(any()) } returns mockk()
+        }
+
+        every { mockTripSegment.realTimeVehicle = any() } just Runs
+
+        viewModel = TripSegmentItemViewModel(
+            context,
+            getTransportIconTintStrategy,
+            tripSegmentHelper,
+            printTime,
+            occupancyViewModel
+        )
+
+    }
+
+    @Test
+    fun `initOccupancy - should call setOccupancy if TripSegment realTimeVehicle is not null`() {
+        val realTimeVehicle = mockk<RealTimeVehicle>()
+        mockTripSegment.realTimeVehicle = realTimeVehicle
+        viewModel.initOccupancy(mockTripSegment)
+
+        verify { occupancyViewModel.setOccupancy(mockTripSegment.realTimeVehicle, any()) }
+    }
+
+    @Test
+    fun `initOccupancy - should not call setOccupancy if TripSegment realTimeVehicle is null`() {
+        every { mockTripSegment.realTimeVehicle } returns null
+        viewModel.initOccupancy(mockTripSegment)
+        verify(exactly = 0) { occupancyViewModel.setOccupancy(any(), any()) }
+    }
+
+}

--- a/TripKitAndroidUI/src/test/java/com/skedgo/tripkit/ui/tripresult/TripSegmentsViewModelTest.kt
+++ b/TripKitAndroidUI/src/test/java/com/skedgo/tripkit/ui/tripresult/TripSegmentsViewModelTest.kt
@@ -1,0 +1,194 @@
+package com.skedgo.tripkit.ui.tripresult
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import com.skedgo.tripkit.TripUpdater
+import com.skedgo.tripkit.datetime.PrintTime
+import com.skedgo.tripkit.routing.TripSegment
+import com.skedgo.tripkit.ui.base.MockKTest
+import com.skedgo.tripkit.ui.base.TripSegmentMock
+import com.skedgo.tripkit.ui.creditsources.CreditSourcesOfDataViewModel
+import com.skedgo.tripkit.ui.routing.settings.RemindersRepository
+import com.skedgo.tripkit.ui.routingresults.TripGroupRepository
+import com.skedgo.tripkit.ui.tripresults.GetTransportIconTintStrategy
+import com.skedgo.tripkit.ui.utils.TripSegmentActionProcessor
+import com.skedgo.tripkit.ui.utils.createSummaryIcon
+import com.skedgo.tripkit.ui.utils.generateTripPreviewHeader
+import com.skedgo.tripkit.ui.utils.getSegmentIconObservable
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import io.reactivex.Observable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import timber.log.Timber
+import java.lang.Exception
+import javax.inject.Provider
+
+@RunWith(MockitoJUnitRunner::class)
+class TripSegmentsViewModelTest : MockKTest() {
+
+    @MockK
+    private lateinit var context: Context
+
+    @MockK
+    private lateinit var printTime: PrintTime
+
+    @MockK(relaxed = true)
+    private lateinit var itemProvider: Provider<TripSegmentItemViewModel>
+
+    @MockK(relaxed = true)
+    private lateinit var creditSourcesOfDataViewModelProvider: Provider<CreditSourcesOfDataViewModel>
+
+    @MockK
+    private lateinit var updateForRealtime: UpdateTripForRealtime
+
+    @MockK(relaxed = true)
+    private lateinit var tripGroupRepository: TripGroupRepository
+
+    @MockK
+    private lateinit var tripSegmentActionProcessor: TripSegmentActionProcessor
+
+    @MockK
+    private lateinit var getAlternativeTripForAlternativeService: GetAlternativeTripForAlternativeService
+
+    @MockK
+    private lateinit var tripUpdater: TripUpdater
+
+    @MockK
+    private lateinit var remindersRepository: RemindersRepository
+
+    @MockK(relaxed = true)
+    private lateinit var getTransportIconTintStrategy: GetTransportIconTintStrategy
+
+    private lateinit var viewModel: TripSegmentsViewModel
+
+    private val mockDrawable = mockk<Drawable>(relaxed = true)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Before
+    fun setup() {
+
+        val testDispatcher = TestCoroutineDispatcher()
+        Dispatchers.setMain(testDispatcher)
+
+        MockKAnnotations.init(this)
+
+        viewModel = TripSegmentsViewModel(
+            context,
+            printTime,
+            itemProvider,
+            creditSourcesOfDataViewModelProvider,
+            updateForRealtime,
+            tripGroupRepository,
+            tripSegmentActionProcessor,
+            getAlternativeTripForAlternativeService,
+            tripUpdater,
+            remindersRepository,
+            getTransportIconTintStrategy
+        )
+    }
+
+    private fun mockDrawableGeneration(isPositive: Boolean) {
+        mockkStatic("com.skedgo.tripkit.ui.utils.TripSegmentUIExtensionKt")
+
+        if (isPositive) {
+            every {
+                any<TripSegment>().getSegmentIconObservable(
+                    any(),
+                    any()
+                )
+            } returns Observable.just(
+                mockDrawable
+            )
+            every { any<TripSegment>().createSummaryIcon(any(), any()) } returns mockDrawable
+        } else {
+            every {
+                any<TripSegment>().getSegmentIconObservable(
+                    any(),
+                    any()
+                )
+            } returns Observable.error(Exception("Test Error"))
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain() // reset the main dispatcher to the original Main dispatcher
+        unmockkStatic("com.skedgo.tripkit.ui.utils.TripSegmentUIExtensionKt")
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `generateSummaryItems - should call generateTripPreviewHeader for each segment in list`() =
+        runTest {
+            mockDrawableGeneration(true)
+            val segments = TripSegmentMock.getTripSegments()
+
+            viewModel.generateSummaryItems(segments)
+
+            verify {
+                TripSegmentMock.tripSegmentScheduled.generateTripPreviewHeader(
+                    any(),
+                    mockDrawable,
+                    any()
+                )
+                TripSegmentMock.tripSegmentArrival.generateTripPreviewHeader(
+                    any(),
+                    mockDrawable,
+                    any()
+                )
+                TripSegmentMock.tripSegmentDeparture.generateTripPreviewHeader(
+                    any(),
+                    mockDrawable,
+                    any()
+                )
+            }
+        }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `generateSummaryItems - should not call generateTripPreviewHeader and throws exception`() =
+        runTest {
+            mockDrawableGeneration(false)
+            mockkStatic(Timber::class)
+            val segments = TripSegmentMock.getTripSegments()
+
+            viewModel.generateSummaryItems(segments)
+
+            verify(exactly = 0) {
+                TripSegmentMock.tripSegmentScheduled.generateTripPreviewHeader(
+                    any(),
+                    mockDrawable,
+                    any()
+                )
+                TripSegmentMock.tripSegmentArrival.generateTripPreviewHeader(
+                    any(),
+                    mockDrawable,
+                    any()
+                )
+                TripSegmentMock.tripSegmentDeparture.generateTripPreviewHeader(
+                    any(),
+                    mockDrawable,
+                    any()
+                )
+            }
+
+            verify { Timber.e(any<Exception>()) }
+            unmockkStatic(Timber::class)
+        }
+}


### PR DESCRIPTION
**Changes**
[19947]
- [TripKitUI] Showing Crowdiness on Trip details segment. 
- [TripKitUI] Minor ui adjustments on road tags
- [TripKitUI] Add Trip summary preview on Trip details

[20385]
- [TripKitUI] Fix RoadTags and Occupancy getting duplicated when creating stationary item on trip segments in Trip details view

[20406]
- [TripKitUI] Fix scrolling issue on TripDetails due to BottomSheet, ViewPager and Recyclerview touch conflicts


**Unit Tests**
<img width="1440" alt="Screenshot 2024-01-18 at 7 24 56 PM" src="https://github.com/skedgo/tripkit-android-ui/assets/13358867/1cc12c4b-d563-4aa5-9935-7699fe594469">

<img width="1440" alt="Screenshot 2024-01-23 at 10 22 51 PM" src="https://github.com/skedgo/tripkit-android-ui/assets/13358867/97ba5279-5ea8-45b2-bc98-98ae5efd2428">
