### PR TITLE
[20619] DRT booking with not ticket fix & [20734] Ticket api call spam fix

### DIFF
--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/payment/PaymentData.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/payment/PaymentData.kt
@@ -23,7 +23,8 @@ data class PaymentData(
     val publishableApiKey: String?,
     val ephemeralKey: EphemeralKey?,
     val areInputsValid: Boolean,
-    val billingEnabled: Boolean
+    val billingEnabled: Boolean,
+    val hasTickets: Boolean
 ) {
     fun getTotalValue(): String {
         var total = 0.0


### PR DESCRIPTION
- [TripGov5] update DrtFragment and include hasTickets field on PaymentData
- [TripGov5] update DrtViewModel and remove enableBooking liveData since the usage is wrong and also update the logic for valid input checking
- [TripGov5] update HomeBottomSheetFragment to handle onPause for HomeBottomSheetItemManagers pause state
- [TripKit] update QuickBooking to make fares nullable
- [TripGov5] update TransitTicketItem to handle cancelling on pause and running polling on resume