### PR TITLE
[24020] Updated stale pr workflow

### DIFF
--- a/.github/workflows/auto_stale_pr.yml
+++ b/.github/workflows/auto_stale_pr.yml
@@ -1,0 +1,17 @@
+name: 'Mark stale issues and PRs'
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 5 days with no activity.'
+          stale-pr-message: 'This pull request is stale because it has been open 5 days with no activity.'
+          days-before-stale: 5
+          days-before-close: -1
+          remove-stale-when-updated: true


### PR DESCRIPTION
# Pull Request (PR) Checklist

## PR Context

- **Type**: Refactor
- **Issue Link**: [Update Stale GitHub Workflow to Only Mark, Not Close Issues/PRs](https://redmine.buzzhives.com/issues/24020)
- **Risk Factor**: Low - This change updates the workflow to avoid accidental PR/issue closure and improves stale handling.

## Changes

- Configured the workflow to only mark issues and PRs as stale after 5 days of inactivity.
- Disabled automatic closing of both issues and PRs by setting days-before-close: -1.
- Enabled remove-stale-when-updated to automatically remove the stale label when activity is detected.

### Error Handling and Logging
- [x] **Logging**: GitHub Actions run logs will reflect changes