### PR TITLE
[24705] - Fix decommissioned stops not being removed from cache

### DIFF
--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/core/StopsPersistor.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/core/StopsPersistor.kt
@@ -28,6 +28,13 @@ class StopsPersistor @Inject constructor(
     override fun saveStopsSync(cells: List<LocationsResponse.Group>) {
         Timber.i("DEBUG: StopsPersistor.saveStopsSync called with ${cells.size} cells")
         
+        // Fix: Delete old stops for cells being updated to remove decommissioned stops
+        // Efficient: Only deletes for specific cells, not entire database. Room uses indexed WHERE clause.
+        val cellIds = cells.mapNotNull { it.key }
+        if (cellIds.isNotEmpty()) {
+            scheduledStopRepository.deleteByCellCodesSync(cellIds)
+        }
+        
         val scheduledStops = mutableListOf<ScheduledStopEntity>()
         val locations = mutableListOf<LocationEntity>()
 

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/ScheduledStopRepository.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/ScheduledStopRepository.kt
@@ -106,6 +106,20 @@ open class ScheduledStopRepository @Inject constructor(
             .subscribeOn(Schedulers.io())
     }
 
+    /**
+     * Synchronous deletion of stops by cell codes. Used during stop save to remove decommissioned stops.
+     * Efficient: Only deletes stops for cells being updated, not entire database.
+     */
+    fun deleteByCellCodesSync(cellCodes: List<String>) {
+        if (cellCodes.isEmpty()) return
+        
+        // Delete in single transaction via Room - efficient for bulk operations
+        val deletedStops = scheduledStopDatabase.scheduledStopDao().deleteScheduledStopsByCellCodes(cellCodes)
+        val deletedLocations = scheduledStopDatabase.scheduledStopDao().deleteLocationsByCellCodes(cellCodes)
+        
+        Timber.d("Deleted old data for ${cellCodes.size} cells: $deletedStops stops, $deletedLocations locations")
+    }
+
     fun update(
         selection: String?,
         selectionArgs: Array<String>?,


### PR DESCRIPTION
## PR Context

- **Type**: Bug Fix
- **Issue Link**: [MyWay+: Android app showing decommissioned stop](https://redmine.buzzhives.com/issues/24705)
- **Risk Factor**: Low

## Changes
- Add deletion logic before inserting updated stops to remove decommissioned stops
- Only deletes stops for cells being updated (efficient, indexed WHERE clause)
- Fixes issue where users see decommissioned stops until clearing app cache
- Update tripkit-android submodule with hash code validation fix

## Checklist for Reviewers

### Documentation and Code Quality
- [x] **KDocs Documentation**: Are all changes, new functionalities, and classes documented with KDocs?
- [x] **Architectural Patterns**: Is there consistent and proper use of architectural patterns (e.g., MVVM, MVP)?

### Testing and Reliability
- [ ] **Unit Testing**: Are there unit tests for all new functionalities and classes?
- [x] **Emulator and Real Device Testing**: Has the application been tested on both emulators and real devices to ensure compatibility?

### Error Handling and Logging
- [x] **Error Handling**: Are errors and exceptions caught and handled gracefully, ensuring the app remains stable?
- [x] **Logging**: Is there proper logging in place for critical errors and information, aiding in debugging and monitoring?


## Testing Procedure

**Step 1: Prepare for Marker Deletion**

1. Launch the app on the beta server.
3. Locate and interact with the marker stop (the "fake stop") you want to remove. This interaction forces the app to register that the stop should no longer exist.

**Step 2: Switch to the Production Environment**

1. Enable Developer Options in the app settings.
3. In the Developer Options menu, change the server environment to "Production".
5. Exit the Developer Options page.

**Step 3: Verify and Clear the Cache**

1. Observe the map: The marker will likely still appear on the map at this point. This is expected because the app initially pulls the stop from a local database cache.
3. Manually close and restart the app completely (do not just minimize it).
5. The Stop is Removed: On the next launch, the app will run the production server logic before checking the database, and the stop should no longer show on the map.
