### PR TITLE
[25051] Fix UninitializedPropertyAccessException in TimetableMapContributor when setContributor called before fragment attachment

### DIFF
--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/timetables/TimetableMapContributor.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/timetables/TimetableMapContributor.kt
@@ -143,6 +143,15 @@ class TimetableMapContributor(val fragment: Fragment) : TripKitMapContributor {
         // Start periodic updates
         startMarkerUpdateInterval()
 
+        // Ensure viewModel is initialized before accessing it
+        // This can happen when safeToUseMap is called before fragment is attached (e.g., during contributor switching)
+        // If not initialized, defer the viewModel subscriptions - they will be set up when safeToUseMap is called again
+        // after the fragment is attached (via onAttachFragment callback)
+        if (!::viewModel.isInitialized) {
+            Timber.w("TimetableMapContributor - viewModel not initialized yet, deferring viewModel subscriptions. Map reference saved, will setup subscriptions after fragment attachment.")
+            return
+        }
+
         //map.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(mStop!!.lat, mStop!!.lon), 15.0f))
 
         autoDisposable.add(
@@ -210,8 +219,11 @@ class TimetableMapContributor(val fragment: Fragment) : TripKitMapContributor {
     }
 
     private fun cleanupServiceDetailVehicleUpdates() {
-        // Stop real-time updates
-        viewModel.stopRealtimeUpdates()
+        // Stop real-time updates - only if viewModel is initialized
+        // This can happen when cleanup is called before fragment is attached (e.g., during contributor switching)
+        if (::viewModel.isInitialized) {
+            viewModel.stopRealtimeUpdates()
+        }
 
         // Cleanup pulse animation
         hidePulseOverlay(pulseOverlay)
@@ -226,13 +238,19 @@ class TimetableMapContributor(val fragment: Fragment) : TripKitMapContributor {
     }
 
     fun setService(service: TimetableEntry?) {
-        viewModel.service.accept(service)
         this.service = service
+        // Only set viewModel if it's initialized (will be set in onActivityCreated after fragment attachment)
+        if (::viewModel.isInitialized) {
+            viewModel.service.accept(service)
+        }
     }
 
     fun setStop(stop: ScheduledStop?) {
         mStop = stop
-        viewModel.stop.accept(stop)
+        // Only set viewModel if it's initialized (will be set in onActivityCreated after fragment attachment)
+        if (::viewModel.isInitialized) {
+            viewModel.stop.accept(stop)
+        }
     }
 
     private fun centerMapOver(map: GoogleMap, coordinates: List<LatLng>?) {


### PR DESCRIPTION
# Pull Request (PR) Checklist

Thank you for your contribution! Please confirm that you've checked all the boxes below before submitting your PR. Use `[x]` to check a box, e.g., `[x]`, and make sure there's no space around the brackets.

## PR Context

- **Type**: Bug Fix
- **Issue Link**: [Redmine Issue #25051](https://redmine.buzzhives.com/issues/25051)
- **Risk Factor**: Medium - This fix affects fragment lifecycle initialization timing. While the changes add defensive checks that should be safe, improper fragment lifecycle handling could affect map contributor behavior during state restoration or rapid navigation.

## Changes

_Fix for UninitializedPropertyAccessException when clicking timetable entries - the Service Detail screen would not appear because viewModel was accessed before fragment attachment._

- Added initialization guard in `safeToUseMap()` to check if `viewModel` is initialized before accessing it. If not initialized, the method returns early after saving the map reference, allowing setup to complete when `safeToUseMap()` is called again after fragment attachment (via `onAttachFragment` callback).

- Added initialization guard in `cleanupServiceDetailVehicleUpdates()` to safely call `viewModel.stopRealtimeUpdates()` only when `viewModel` is initialized.

- Added initialization guards in `setService()` and `setStop()` methods to prevent accessing `viewModel` before injection completes, even though these methods are typically called after fragment attachment.

**Root Cause**: When `loadDetails()` calls `setContributor(serviceDetailsFragment?.contributor())` before the fragment transaction completes, `TripKitMapFragment.setContributor()` immediately calls `safeToUseMap()` on the contributor. However, `viewModel` is only injected when `ServiceDetailFragment.onAttach()` calls `mapContributor.initialize()`, which hasn't occurred yet at that point.

## Checklist for Reviewers

### Documentation and Code Quality

- [x] **KDocs Documentation**: Added inline comments explaining why initialization guards are necessary and when deferred setup occurs.

- [x] **Architectural Patterns**: Maintains existing MVVM architecture. Changes are defensive and don't alter the architectural pattern.

### Testing and Reliability

- [ ] **Unit Testing**: No unit tests added (lifecycle-dependent behavior - would require fragment testing framework setup)

- [x] **Emulator and Real Device Testing**: Tested on emulator and confirmed timetable navigation works correctly.

### Error Handling and Logging

- [x] **Error Handling**: Prevents `UninitializedPropertyAccessException` by checking initialization state before accessing `viewModel`. Gracefully defers setup until proper lifecycle stage.

- [x] **Logging**: Added warning log when `viewModel` is not initialized to aid in debugging if similar issues occur.

## Testing Procedure

_Steps to verify the fix works correctly:_

1. Open the app and navigate to a timetable (e.g., from a trip result or by searching for a stop)
2. Click on any timetable entry/service
3. **Expected**: Service Detail screen should appear immediately showing stop details, service information, and map markers
4. Verify that clicking back returns to the timetable view correctly
5. Test multiple rapid clicks to ensure no crashes occur
6. Test with app restoration (minimize app, restore) to ensure state restoration still works correctly

**Before Fix**: Clicking timetable entries would not navigate to Service Detail screen, and logcat would show `UninitializedPropertyAccessException: lateinit property viewModel has not been initialized` error.

**After Fix**: Service Detail screen appears correctly, no exceptions in logcat.

## Work-in-Progress (WIP)

- [ ] None - Fix is complete

_Remember to keep this template updated based on the feedback and evolving project standards._