### PR TITLE
[24390] Fix typo in strings.xml and improve Crowdin workflow automation

### DIFF
--- a/.github/workflows/CROWDIN_WORKFLOWS.md
+++ b/.github/workflows/CROWDIN_WORKFLOWS.md
@@ -1,0 +1,72 @@
+# Crowdin Integration Workflows
+
+This directory contains workflows for managing translations with Crowdin.
+
+## Workflows
+
+### 1. `crowdin_upload.yml` - Upload Source Strings
+**Purpose**: Automatically uploads source strings (`strings.xml`) to Crowdin when changes are pushed.
+
+**Triggers**:
+- ✅ **Automatic**: When `TripKitAndroidUI/src/main/res/values/strings.xml` is pushed to `develop`, `main`, or `master`
+- ✅ **Manual**: Can be triggered manually via GitHub Actions UI
+
+**What it does**:
+- Uploads the source `strings.xml` file to Crowdin
+- Translators can then work on the new/updated strings
+
+### 2. `crowdin_download.yml` - Download Translations
+**Purpose**: Downloads completed translations from Crowdin and creates a PR.
+
+**Triggers**:
+- ✅ **Manual only**: Triggered manually via GitHub Actions UI when you need updated translations
+
+**What it does**:
+- Downloads all translations from Crowdin
+- Creates a Pull Request with the updated translation files
+- PR is created against the `develop` branch
+
+## Workflow
+
+```
+Developer fixes typo/adds string
+         ↓
+Merge PR to develop branch
+         ↓
+crowdin_upload.yml runs automatically
+         ↓
+Source uploaded to Crowdin
+         ↓
+Translators work on translations
+         ↓
+crowdin_download.yml runs (manual trigger)
+         ↓
+PR created with updated translations
+         ↓
+Review & merge PR
+```
+
+## Benefits of New Workflow
+
+1. **Automatic sync**: Source changes automatically upload to Crowdin (after merge to develop)
+2. **Manual control**: Translations are pulled on-demand when needed
+3. **Separation of concerns**: Upload and download are separate
+4. **Better PR descriptions**: More informative PR messages
+5. **Path-based triggers**: Only runs when relevant files change
+6. **No noise**: Only uploads after merge to avoid WIP strings
+
+## Manual Operations
+
+If you need to manually sync:
+
+1. **Upload sources**: Go to Actions → "Crowdin Upload Sources" → Run workflow
+2. **Download translations**: Go to Actions → "Crowdin Download Translations" → Run workflow
+
+## Configuration
+
+Required secrets (set in GitHub repository settings):
+- `CROWDIN_PROJECT_ID`
+- `CROWDIN_PERSONAL_TOKEN`
+
+Configuration file: `crowdin.yml` in the repository root.
+

--- a/.github/workflows/crowdin_ci.yml
+++ b/.github/workflows/crowdin_ci.yml
@@ -1,4 +1,10 @@
-name: Crowdin Action
+name: Crowdin Action (DEPRECATED)
+
+# ⚠️ DEPRECATED: This workflow has been replaced by:
+# - crowdin_upload.yml (automatic upload on source changes)
+# - crowdin_download.yml (scheduled + manual downloads)
+# 
+# This file is kept for backward compatibility but will be removed in the future.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/crowdin_download.yml
+++ b/.github/workflows/crowdin_download.yml
@@ -1,0 +1,50 @@
+name: Crowdin Download Translations
+
+# Download translations from Crowdin
+# Manual trigger only - run when you need to pull updated translations
+on:
+  workflow_dispatch:  # Manual trigger only
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  download-translations:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download translations from Crowdin
+        uses: crowdin/github-action@v1
+        with:
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: crowdin_translations_update
+          create_pull_request: true
+          pull_request_title: '🌐 New Crowdin Translations'
+          pull_request_body: |
+            ## New Crowdin Translations
+            
+            This PR contains updated translations from Crowdin.
+            
+            - **Source**: Crowdin project
+            - **Triggered by**: ${{ github.event_name }}
+            - **Workflow run**: [View details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            
+            Please review the changes, especially for:
+            - New translations that need verification
+            - Updated translations that may have changed
+            - Any missing translations
+            
+            _This PR was automatically created by the Crowdin GitHub Action._
+          pull_request_base_branch_name: 'develop'
+          commit_message: 'chore: update translations from Crowdin'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+

--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -1,0 +1,36 @@
+name: Crowdin Upload Sources
+
+# Upload source strings to Crowdin when strings.xml changes
+# Only triggers after merge to develop/main/master to avoid noise from WIP feature branches
+on:
+  push:
+    branches:
+      - develop
+      - main
+      - master
+    paths:
+      - 'TripKitAndroidUI/src/main/res/values/strings.xml'
+  workflow_dispatch:  # Keep manual trigger as backup
+
+permissions:
+  contents: write
+
+jobs:
+  upload-sources:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Upload sources to Crowdin
+        uses: crowdin/github-action@v1
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+

--- a/TripKitAndroidUI/src/main/res/values/strings.xml
+++ b/TripKitAndroidUI/src/main/res/values/strings.xml
@@ -264,7 +264,7 @@
     <!--This usually means that there's no discount for some service. For instance, a user may need to pay full fare for a transport mode not included in his/her mobility bundle.-->
     <string name="full_fare">Full fare</string>
     <!--No comment provided by engineer.-->
-    <string name="get_updated_etas_while_you_apostre_on_a_trip_by_reporting_you_current_location_back_to_our_servers_dot_this_also_helps_improve_our_travel_time_prediction_dot_we_may_share_this_data_with_our_partners_who_help_us_make_those_predictions_dot">Get updated ETAs while you\'re on a trip by reporting you current location back to our servers. This also helps improve our travel time prediction.
+    <string name="get_updated_etas_while_you_apostre_on_a_trip_by_reporting_you_current_location_back_to_our_servers_dot_this_also_helps_improve_our_travel_time_prediction_dot_we_may_share_this_data_with_our_partners_who_help_us_make_those_predictions_dot">Get updated ETAs while you\'re on a trip by reporting your current location back to our servers. This also helps improve our travel time prediction.
 We may share this data with our partners who help us make those predictions.</string>
     <!--No comment provided by engineer.-->
     <string name="help_improve_transport_services_in_your_area_by_allowing_us_to_collect_information_about_which_trips_you_select_in_the_app_dot_we_aggregate_the_anonymised_data_and_provide_it_to_researchers_coma_regulators_coma_and_transport_providers_dot">Help improve transport services in your area by allowing us to collect information about which trips you select in the app.


### PR DESCRIPTION
## PR Context

- **Type**: Bug Fix / Feature
- **Issue Link**: [Redmine Issue](https://redmine.buzzhives.com/issues/24390)
- **Risk Factor**: Low - String resource fix and workflow automation improvements that don't affect app runtime behavior

## Changes

_Describe your changes in detail, highlighting the problem it solves or the feature it adds._

- **Fixed typo in strings.xml**: Changed "you current location" to "your current location" in the privacy/location sharing description string
- **Added automatic Crowdin upload workflow** (`crowdin_upload.yml`): Automatically uploads source strings to Crowdin when `strings.xml` changes are merged to `develop`/`main`/`master`
- **Added manual Crowdin download workflow** (`crowdin_download.yml`): Allows on-demand download of translations from Crowdin, creating a PR with updated translation files
- **Deprecated old workflow** (`crowdin_ci.yml`): Marked as deprecated in favor of the new separated workflows
- **Added documentation** (`CROWDIN_WORKFLOWS.md`): Comprehensive documentation explaining the new Crowdin integration workflows

## Checklist for Reviewers

### Documentation and Code Quality
- [x] **KDocs Documentation**: N/A - No code changes, only string resources and workflow files
- [x] **Architectural Patterns**: N/A - Workflow configuration files, not application code

### Testing and Reliability
- [x] **Unit Testing**: N/A - Workflow files and string resources don't require unit tests
- [ ] **Emulator and Real Device Testing**: String change should be verified in the app UI where this privacy description is displayed (likely in settings/permissions screen)

### Error Handling and Logging
- [x] **Error Handling**: N/A - Workflow files use standard Crowdin GitHub Action error handling
- [x] **Logging**: N/A - Workflow actions provide standard GitHub Actions logging

## Testing Procedure

_If applicable, provide steps or commands for testing your changes. This can help reviewers and testers._

- **String typo fix**: 
  - Navigate to the screen where location sharing/privacy description is shown (likely in app settings or permissions screen)
  - Verify the text now reads "your current location" instead of "you current location"
  
- **Workflow testing** (after merge):
  - After merging this PR, verify that `crowdin_upload.yml` appears in GitHub Actions
  - Make a test change to `strings.xml` and merge to `develop` to verify automatic upload triggers
  - Manually trigger `crowdin_download.yml` from GitHub Actions to verify it creates a PR with translations
