### PR TITLE
[25083] Upgrade AGP to 8.6.0 and migrate deprecated APIs

### DIFF
--- a/TripKitAndroidUI/build.gradle
+++ b/TripKitAndroidUI/build.gradle
@@ -63,9 +63,7 @@ android {
         dataBinding true
     }
 
-    dexOptions {preDexLibraries = true} // To enable build-cache.
-
-    lintOptions {
+    lint {
         checkReleaseBuilds true
         abortOnError false
     }

--- a/TripKitAndroidUIModules/TripKitAndroidUIData/build.gradle
+++ b/TripKitAndroidUIModules/TripKitAndroidUIData/build.gradle
@@ -6,8 +6,6 @@ apply plugin: 'kotlin-parcelize'
 
 android {
     compileSdkVersion versions.compileSdkVersion
-    buildToolsVersion "33.0.0"
-
 
     defaultConfig {
         minSdkVersion versions.proMinSdkVersion

--- a/TripKitAndroidUIModules/TripKitAndroidUIDomain/build.gradle
+++ b/TripKitAndroidUIModules/TripKitAndroidUIDomain/build.gradle
@@ -6,8 +6,6 @@ apply plugin: 'kotlin-parcelize'
 
 android {
     compileSdkVersion versions.compileSdkVersion
-    buildToolsVersion "33.0.0"
-
 
     defaultConfig {
         minSdkVersion versions.proMinSdkVersion

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
 
     dependencies {
@@ -38,7 +37,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
         maven { url 'https://repository.liferay.com/nexus/content/repositories/public/' }
         maven { url "https://jitpack.io" }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Jan 09 11:42:50 CET 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/tripkituisample/build.gradle
+++ b/tripkituisample/build.gradle
@@ -41,7 +41,7 @@ android {
             signingConfig signingConfigs.release
         }
     }
-    lintOptions { abortOnError false }
+    lint { abortOnError false }
     compileOptions {
         coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_17


### PR DESCRIPTION
## PR Context

- **Type**: Refactor
- **Issue Link**: [Redmine Issue](https://redmine.buzzhives.com/issues/25083)
- **Risk Factor**: Medium - Build configuration changes to support AGP 8.6.0 upgrade. All builds verified to work correctly.

## Changes

Update build configuration to support AGP 8.6.0 upgrade and remove deprecated APIs.

- Updated Gradle Wrapper from 8.4 to 8.10 in `gradle/wrapper/gradle-wrapper.properties` (required for AGP 8.6.0, minimum Gradle 8.7+)
- Removed `jcenter()` repository references (deprecated, shut down 2021) from `build.gradle` (2 locations)
- Migrated `lintOptions` to `lint {}` API in `TripKitAndroidUI/build.gradle` and `tripkituisample/build.gradle`
- Removed `buildToolsVersion` from `TripKitAndroidUIModules/TripKitAndroidUIData/build.gradle` and `TripKitAndroidUIModules/TripKitAndroidUIDomain/build.gradle` (AGP 8.x manages automatically)

## Checklist for Reviewers

### Documentation and Code Quality
- [x] **KDocs Documentation**: Build configuration changes, no new classes or functionality requiring KDocs
- [x] **Architectural Patterns**: No architectural changes, build system upgrade only

### Testing and Reliability
- [x] **Unit Testing**: Build configuration changes, no code changes requiring new unit tests
- [x] **Emulator and Real Device Testing**: Builds verified successfully:
  - `:TripKitAndroidUI:assemble` - BUILD SUCCESSFUL
  - `:TripKitAndroidUI:assembleRelease` - BUILD SUCCESSFUL

### Error Handling and Logging
- [x] **Error Handling**: Build configuration changes, no runtime error handling changes
- [x] **Logging**: No logging changes required

## Testing Procedure

Run the following commands to verify the changes. **Note**: Build commands can be run from either the **root project directory** (`tripgo-v5-android`) or from the `tripkit-android-ui` directory:

```bash
# Verify builds succeed (can run from tripkit-android-ui directory OR root project)
cd tripkit-android-ui
./gradlew :TripKitAndroidUI:assemble
./gradlew :TripKitAndroidUI:assembleRelease
# Expected: BUILD SUCCESSFUL

# Alternative: Run from root project directory
cd ..
./gradlew :TripKitAndroidUI:assemble
./gradlew :TripKitAndroidUI:assembleRelease
# Expected: BUILD SUCCESSFUL

# Verify deprecated APIs removed (run from tripkit-android-ui directory)
cd tripkit-android-ui
grep -r "lintOptions\|buildToolsVersion\|jcenter()" --include="*.gradle" . 2>/dev/null | grep -v "PR_\|GRADLE_AGP\|README\|tripkit-android/" || echo "✓ No deprecated APIs found"
# Expected: No matches (or only in comments/documentation)
```

## Work-in-Progress (WIP)

- [x] Gradle Wrapper updated to 8.10
- [x] All build configuration changes completed
- [x] Gradle Wrapper updated to 8.10
- [x] All builds verified (from root and independently) (from root and independently)
- [x] Deprecated APIs migrated

_Remember to keep this template updated based on the feedback and evolving project standards._

