### PR TITLE
[25358] Aligned flexbox justify content to start

### DIFF
--- a/TripKitAndroidUI/src/main/res/layout/trip_result_list_item_trip.xml
+++ b/TripKitAndroidUI/src/main/res/layout/trip_result_list_item_trip.xml
@@ -78,7 +78,7 @@
             app:entries="@{viewModel.segments}"
             app:flexDirection="row"
             app:flexWrap="wrap"
-            app:justifyContent="space_between"
+            app:justifyContent="flex_start"
             app:alignItems="flex_start"
             android:scrollbars="none"
             android:scrollIndicators="none"


### PR DESCRIPTION
## PR Context

- **Type**: Regression Fix)
- **Issue Link**: [Align Trip Result Segment items with iOS and legacy Android implementation
](https://redmine.buzzhives.com/issues/25358)
- **Risk Factor**: Low - UI-only change affecting alignment within a specific list item.

## Changes

_Describe your changes in detail, highlighting the problem it solves or the feature it adds._

- Layout Update: Modified trip_result_list_item_trip.xml to change the FlexboxLayout alignment logic.
- Justification: Changed justifyContent from space_between to flex_start.
- Retention: Kept flexWrap="wrap" and alignItems="flex_start" to ensure that multi-line segments or large accessibility text sizes still wrap correctly without overlapping.
- Scope: No changes were required in trip_result_segment_item.xml, as positioning is managed by the parent container.

## Checklist for Reviewers

### Documentation and Code Quality
- [ ] **KDocs Documentation**: Are all changes, new functionalities, and classes documented with KDocs?
- [ ] **Architectural Patterns**: Is there consistent and proper use of architectural patterns (e.g., MVVM, MVP)?

### Testing and Reliability
- [ ] **Unit Testing**: Are there unit tests for all new functionalities and classes?
- [x] **Emulator and Real Device Testing**: Has the application been tested on both emulators and real devices to ensure compatibility?

### Error Handling and Logging
- [ ] **Error Handling**: Are errors and exceptions caught and handled gracefully, ensuring the app remains stable?
- [ ] **Logging**: Is there proper logging in place for critical errors and information, aiding in debugging and monitoring?


## Testing Procedure

_If applicable, provide steps or commands for testing your changes. This can help reviewers and testers._

- Open the Trip Results screen.
- Observe the segment chips (e.g., transport icons/labels).
- Verify Alignment: Confirm chips are packed to the left (flex_start) rather than spreading to fill the width.
- Verify Wrapping: Increase system font size or view a trip with many segments to ensure items still wrap to the next line correctly.
- Comparison: Cross-check with the iOS app to ensure visual parity.
