### PR TITLE
[25484] - align trip selection reporting with iOS parity

### DIFF
--- a/TripKitAndroidUIModules/TripKitAndroidUIData/src/main/java/com/skedgo/tripkit/ui/data/personaldata/MyPersonalDataRepositoryImpl.kt
+++ b/TripKitAndroidUIModules/TripKitAndroidUIData/src/main/java/com/skedgo/tripkit/ui/data/personaldata/MyPersonalDataRepositoryImpl.kt
@@ -28,8 +28,9 @@ class MyPersonalDataRepositoryImpl @Inject constructor(
 
     override fun isUploadTripSelectionEnabled(): Single<Boolean> {
         return Single.fromCallable {
-//      sharedPreferences.getBoolean(tripSelection, true) // TripSelection is opt-out
-            true
+            // Opt-in by default. This flag controls whether userToken is included
+            // in planned-trip reporting for de-duplication.
+            sharedPreferences.getBoolean(tripSelection, false)
         }
     }
 

--- a/TripKitAndroidUIModules/TripKitAndroidUIDomain/src/main/java/com/skedgo/tripkit/analytics/ReportPlannedTrip.kt
+++ b/TripKitAndroidUIModules/TripKitAndroidUIDomain/src/main/java/com/skedgo/tripkit/analytics/ReportPlannedTrip.kt
@@ -1,10 +1,17 @@
 package com.skedgo.tripkit.analytics
 
+import com.skedgo.TripKit
 import com.skedgo.tripkit.routing.Trip
 import com.skedgo.tripkit.ui.personaldata.MyPersonalDataRepository
 import io.reactivex.Observable
 import javax.inject.Inject
 
+/**
+ * Reports a selected trip with choice-set analytics.
+ *
+ * Trip selection reporting is always sent. The personal data setting only
+ * controls whether userToken is attached for de-duplication.
+ */
 open class ReportPlannedTrip @Inject constructor(
     private val myPersonalDataRepository: MyPersonalDataRepository,
     private val markTripAsPlannedWithUserInfo: MarkTripAsPlannedWithUserInfo
@@ -13,9 +20,24 @@ open class ReportPlannedTrip @Inject constructor(
         selectedTrip: Trip,
         getChoiceSet: List<Choice>
     ): Observable<Unit> {
-        return markTripAsPlannedWithUserInfo.execute(
-            selectedTrip.plannedURL ?: "",
-            userInfo = UserInfo(getChoiceSet).toMutableMap()
-        )
+        return myPersonalDataRepository.isUploadTripSelectionEnabled()
+            .toObservable()
+            .flatMap { shouldIncludeUserToken ->
+                val userInfo = UserInfo(getChoiceSet).toMutableMap()
+                if (shouldIncludeUserToken) {
+                    val userToken = runCatching {
+                        TripKit.getInstance().configs().userTokenProvider()?.call()
+                    }.getOrNull()
+
+                    if (!userToken.isNullOrBlank()) {
+                        userInfo["userToken"] = userToken
+                    }
+                }
+
+                markTripAsPlannedWithUserInfo.execute(
+                    selectedTrip.plannedURL ?: "",
+                    userInfo = userInfo
+                )
+            }
     }
 }


### PR DESCRIPTION
## PR Context

- **Type**: Bug Fix
- **Issue Link**: [Redmine Issue](https://redmine.buzzhives.com/issues/25484)
- **Risk Factor**: Low - Change is scoped to personal data preference persistence and planned-trip payload enrichment (`userToken`) with compile verification completed.

## Changes

_Describe your changes in detail, highlighting the problem it solves or the feature it adds._

- Fixed Trip Selections preference persistence by removing hardcoded `true` and reading from `SharedPreferences`.
- Updated Trip Selections default behavior to **opt-in** (`false` by default) to match ticket requirement and iOS parity.
- Updated planned-trip reporting to always send `choiceSet` while conditionally adding `userToken` only when Trip Selections is enabled.

## Checklist for Reviewers

### Documentation and Code Quality
- [x] **KDocs Documentation**: Are all changes, new functionalities, and classes documented with KDocs?
- [x] **Architectural Patterns**: Is there consistent and proper use of architectural patterns (e.g., MVVM, MVP)?

### Testing and Reliability
- [ ] **Unit Testing**: Are there unit tests for all new functionalities and classes?
- [x] **Emulator and Real Device Testing**: Has the application been tested on both emulators and real devices to ensure compatibility?

### Error Handling and Logging
- [x] **Error Handling**: Are errors and exceptions caught and handled gracefully, ensuring the app remains stable?
- [ ] **Logging**: Is there proper logging in place for critical errors and information, aiding in debugging and monitoring?

## Testing Procedure

_If applicable, provide steps or commands for testing your changes. This can help reviewers and testers._

- Open `Settings` -> `My Personal Data` and verify `Trip Selections` defaults to OFF on fresh install/cleared data.
- Toggle `Trip Selections` ON/OFF, leave and re-enter the page, and verify state persists correctly.
- Plan a trip between two supported locations and select a trip:
  - With toggle OFF: planned-trip report should include `choiceSet` and exclude `userToken`.
  - With toggle ON: planned-trip report should include both `choiceSet` and `userToken` (when a token is available).