### PR TITLE
[25500] Fix RecyclerView inconsistency crash in trip results updates

### DIFF
--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresults/GroupDiffCallback.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresults/GroupDiffCallback.kt
@@ -3,9 +3,15 @@ package com.skedgo.tripkit.ui.tripresults
 import me.tatarka.bindingcollectionadapter2.collections.DiffObservableList
 
 object GroupDiffCallback : DiffObservableList.Callback<TripResultViewModel> {
-    override fun areItemsTheSame(lhs: TripResultViewModel?, rhs: TripResultViewModel?): Boolean =
-        lhs!! == rhs!!
+    override fun areItemsTheSame(lhs: TripResultViewModel?, rhs: TripResultViewModel?): Boolean {
+        if (lhs === rhs) return true
+        if (lhs == null || rhs == null) return false
+        return lhs.group.uuid() == rhs.group.uuid()
+    }
 
-    override fun areContentsTheSame(lhs: TripResultViewModel?, rhs: TripResultViewModel?): Boolean =
-        lhs!! == rhs!!
+    override fun areContentsTheSame(lhs: TripResultViewModel?, rhs: TripResultViewModel?): Boolean {
+        if (lhs === rhs) return true
+        if (lhs == null || rhs == null) return false
+        return lhs == rhs
+    }
 }

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresults/TripResultListFragment.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresults/TripResultListFragment.kt
@@ -365,7 +365,6 @@ class TripResultListFragment : BaseTripKitFragment() {
 
     fun updateTripGroup(updatedTripGroup: TripGroup) {
         viewModel.updateTripGroup(updatedTripGroup)
-        binding.recyclerView.adapter?.notifyDataSetChanged()
     }
 
     private fun showDateTimePicker(isCancelable: Boolean = true) {

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresults/TripResultListViewModel.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresults/TripResultListViewModel.kt
@@ -49,10 +49,6 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -145,7 +141,6 @@ class TripResultListViewModel @Inject constructor(
     val isError = ObservableBoolean(false)
     val showCloseButton = ObservableBoolean(false)
     private val transportModeChangeThrottle = PublishSubject.create<Unit>()
-    private val resultListUpdateThrottle = PublishSubject.create<Unit>()
 
     val tripGroupList = ObservableArrayList<TripGroup>()
     var tripGroupWithUrlList = arrayListOf<TripGroup>()
@@ -264,13 +259,6 @@ class TripResultListViewModel @Inject constructor(
         transportModeChangeThrottle.debounce(500, TimeUnit.MILLISECONDS)
             .subscribe(
                 { load() },
-                { errorLogger.trackError(it) })
-            .autoClear()
-
-        resultListUpdateThrottle.debounce(800, TimeUnit.MILLISECONDS)
-            .subscribeOn(AndroidSchedulers.mainThread())
-            .subscribe(
-                { customAdapter.notifyDataSetChanged() },
                 { errorLogger.trackError(it) })
             .autoClear()
     }
@@ -732,8 +720,13 @@ class TripResultListViewModel @Inject constructor(
         _showHelpInfo.value = show
     }
 
-    private var updateJob: Job? = null
-
+    /**
+     * Applies a list update to the adapter-backing [DiffObservableList].
+     *
+     * When a pre-computed [DiffUtil.DiffResult] is supplied (from [loadFromStore]),
+     * it dispatches granular insert/remove/move events automatically.
+     * Otherwise [DiffObservableList.update] calculates the diff internally.
+     */
     private fun updateResultList(
         list: List<TripResultViewModel>,
         diffResult: DiffUtil.DiffResult? = null
@@ -742,15 +735,6 @@ class TripResultListViewModel @Inject constructor(
             results.update(list, it)
         } ?: run {
             results.update(list)
-        }
-
-        // Cancel the previous job if it's still active
-        updateJob?.cancel()
-
-        // Launch a new job with a debounce delay
-        updateJob = CoroutineScope(Dispatchers.Main).launch {
-            delay(1000)
-            customAdapter.notifyDataSetChanged()
         }
     }
 


### PR DESCRIPTION
## PR Context

- **Type**: Bug Fix
- **Issue Link**: [RecyclerView Inconsistency crash on Trip Results (mis-flagged as 16KB in pre-launch)(https://redmine.buzzhives.com/issues/25500)
- **Risk Factor**: Low

## Changes

_Describe your changes in detail, highlighting the problem it solves or the feature it adds._

- Removed redundant notifyDataSetChanged() from TripResultListFragment.updateTripGroup().
- Removed delayed/debounced manual adapter full refreshes in TripResultListViewModel (updateJob + resultListUpdateThrottle).
- Kept list updates via DiffObservableList.update(...) only (single source of truth for adapter updates).
- Updated GroupDiffCallback to be null-safe and identity-based (group.uuid() for item identity).

## Checklist for Reviewers

### Documentation and Code Quality
- [x] **KDocs Documentation**: Are all changes, new functionalities, and classes documented with KDocs?
- [x] **Architectural Patterns**: Is there consistent and proper use of architectural patterns (e.g., MVVM, MVP)?

### Testing and Reliability
- [ ] **Unit Testing**: Are there unit tests for all new functionalities and classes?
- [x] **Emulator and Real Device Testing**: Has the application been tested on both emulators and real devices to ensure compatibility?

### Error Handling and Logging
- [x] **Error Handling**: Are errors and exceptions caught and handled gracefully, ensuring the app remains stable?
- [x] **Logging**: Is there proper logging in place for critical errors and information, aiding in debugging and monitoring?
