### PR TITLE
[25500] Harden timetable list updates against adapter inconsistencies

### DIFF
--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/timetables/TimetableFragment.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/timetables/TimetableFragment.kt
@@ -364,6 +364,10 @@ class TimetableFragment : BaseTripKitPagerFragment(), View.OnClickListener {
         binding.viewModel = viewModel
         binding.serviceLineRecyclerView.isNestedScrollingEnabled = false
         binding.recyclerView.isNestedScrollingEnabled = true
+        // Frequent realtime + pagination updates can overlap with item animations and cause
+        // transient RecyclerView inconsistencies on some devices.
+        binding.recyclerView.itemAnimator = null
+        binding.recyclerView.setHasFixedSize(false)
 
 //        val swipeListener = OnSwipeTouchListener(requireContext(),
 //            object : OnSwipeTouchListener.SwipeGestureListener {

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/timetables/TimetableViewModel.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/timetables/TimetableViewModel.kt
@@ -43,10 +43,11 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.functions.BiFunction
 import io.reactivex.rxkotlin.Observables
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.rx2.await
 import kotlinx.coroutines.rx2.awaitFirstOrNull
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import me.tatarka.bindingcollectionadapter2.ItemBinding
 import me.tatarka.bindingcollectionadapter2.collections.DiffObservableList
@@ -75,6 +76,12 @@ class TimetableViewModel @Inject constructor(
     private val getTripFromWaypoints: GetTripFromWaypoints,
     private val tripGroupRepository: TripGroupRepository
 ) : RxViewModel() {
+    /**
+     * Serializes adapter list mutations so we do not interleave diff dispatches while RecyclerView
+     * is still applying a previous update.
+     */
+    private val servicesUpdateMutex = Mutex()
+
     var stop: BehaviorRelay<ScheduledStop> = BehaviorRelay.create()
     var serviceTripId: BehaviorRelay<String> = BehaviorRelay.create()
 
@@ -301,21 +308,7 @@ class TimetableViewModel @Inject constructor(
                 }
 
                 viewModelScope.launch {
-                    withContext(Dispatchers.Default) {
-                        val diff = services.calculateDiff(it)
-                        withContext(Dispatchers.Main) {
-                            // Use delay to ensure RecyclerView is not in the middle of a layout pass
-                            delay(1) // Minimal delay to yield to the main thread
-                            try {
-                                services.update(it, diff)
-                            } catch (e: IndexOutOfBoundsException) {
-                                Timber.e("IndexOutOfBoundsException in services update", e)
-                                // If there's still a race condition, clear and rebuild the list
-                                services.clear()
-                                services.addAll(it)
-                            }
-                        }
-                    }
+                    applyServicesUpdateSafely(it)
                 }
                 val tmpServiceList: MutableList<TimetableHeaderLineItem> =
                     arrayListOf<TimetableHeaderLineItem>()
@@ -410,6 +403,23 @@ class TimetableViewModel @Inject constructor(
 
     fun getShareUrl(shareUrl: String, stop: ScheduledStop) =
         createShareContent.execute(shareUrl, stop, services.map { it.service })
+
+    private suspend fun applyServicesUpdateSafely(nextItems: List<ServiceViewModel>) {
+        servicesUpdateMutex.withLock {
+            val diff = withContext(Dispatchers.Default) { services.calculateDiff(nextItems) }
+            withContext(Dispatchers.Main.immediate) {
+                runCatching {
+                    services.update(nextItems, diff)
+                }.recoverCatching { firstError ->
+                    Timber.w(firstError, "Primary timetable diff apply failed, retrying with fresh diff")
+                    // Retry with a fresh diff against the latest adapter state.
+                    services.update(nextItems)
+                }.onFailure { finalError ->
+                    Timber.e(finalError, "Failed to apply timetable services update safely")
+                }
+            }
+        }
+    }
 
     /**
      * Handles [TimetableEntry] item click


### PR DESCRIPTION
## PR Context

- **Type**: Bug Fix
- **Issue Link**: [RecyclerView Inconsistency crash on Trip Results (mis-flagged as 16KB in pre-launch)(https://redmine.buzzhives.com/issues/25500)
- **Risk Factor**: Low

## Changes

_Describe your changes in detail, highlighting the problem it solves or the feature it adds._

- Serialize timetable DiffObservableList updates and add RecyclerView stability guards to prevent invalid view holder positions during rapid stop switching, realtime refreshes, and resume-driven reloads.

## Checklist for Reviewers

### Documentation and Code Quality
- [x] **KDocs Documentation**: Are all changes, new functionalities, and classes documented with KDocs?
- [x] **Architectural Patterns**: Is there consistent and proper use of architectural patterns (e.g., MVVM, MVP)?

### Testing and Reliability
- [ ] **Unit Testing**: Are there unit tests for all new functionalities and classes?
- [x] **Emulator and Real Device Testing**: Has the application been tested on both emulators and real devices to ensure compatibility?

### Error Handling and Logging
- [x] **Error Handling**: Are errors and exceptions caught and handled gracefully, ensuring the app remains stable?
- [x] **Logging**: Is there proper logging in place for critical errors and information, aiding in debugging and monitoring?
