### PR TITLE
[25550] Preserve multi-color alert and transport icons.

### DIFF
--- a/TripKitAndroidUI/src/main/res/layout/item_service_alert.xml
+++ b/TripKitAndroidUI/src/main/res/layout/item_service_alert.xml
@@ -24,7 +24,6 @@
             android:src="@{item.severity()}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:tint="@color/icon_tint_default"
             tools:src="@drawable/ic_action_warning" />
 
         <TextView

--- a/TripKitAndroidUI/src/main/res/layout/item_trip_segment_summary.xml
+++ b/TripKitAndroidUI/src/main/res/layout/item_trip_segment_summary.xml
@@ -21,7 +21,6 @@
             android:layout_width="@dimen/close_button_size"
             android:layout_height="@dimen/close_button_size"
             android:src="@{viewModel.icon}"
-            app:customImageTint="@{viewModel.selected? @color/colorPrimary : 0}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/TripKitAndroidUI/src/main/res/layout/trip_preview_pager_item_header.xml
+++ b/TripKitAndroidUI/src/main/res/layout/trip_preview_pager_item_header.xml
@@ -19,7 +19,6 @@
             android:layout_marginTop="@dimen/spacing_normal"
             android:layout_marginStart="16dp"
             android:src="@{viewModel.icon}"
-            app:tint="@color/black"
             app:layout_constraintBottom_toBottomOf="@+id/textBarrier"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/TripKitAndroidUI/src/main/res/layout/trip_segment.xml
+++ b/TripKitAndroidUI/src/main/res/layout/trip_segment.xml
@@ -122,7 +122,6 @@
                 android:layout_height="@dimen/segment_item_icon_size"
                 android:layoutDirection="ltr"
                 android:src="@{viewModel.icon}"
-                app:tint="@android:color/white"
                 tools:src="@drawable/ic_train"
                 tools:tint="@android:color/white" />
         </LinearLayout>


### PR DESCRIPTION
## PR Context

- **Type**: Bug Fix
- **Issue Link**: [Redmine Issue](https://redmine.buzzhives.com/issues/25550)
- **Risk Factor**: Low - Layout-level changes only; removed hardcoded icon tints so existing drawable colors render correctly.

## Changes

Point to the TripKit Android UI commit that removes hardcoded alert and transport icon tints in trip details and preview header layouts to prevent flattened icons.

- Removed forced tint from service alert icon to preserve severity icon colors.
- Removed forced tint from trip details segment icon so bus/transport icons are not flattened.
- Removed forced tint from trip preview header and segment summary transport icons to preserve multi-color assets.
- Updated parent repo submodule pointer to include the TripKit Android UI fix commit.

## Commit References

- **TripKit Android UI commit**: `d4a985a2` (`[25550] Preserve multi-color alert and transport icons.`)
- **Parent repo commit**: `520cf2875` (`[25550] Update TripKit UI submodule for icon tint fix.`)

## Checklist for Reviewers

### Documentation and Code Quality
- [x] **KDocs Documentation**: Not applicable (no Kotlin logic or API surface changes; XML tint attributes only).
- [x] **Architectural Patterns**: Existing architecture unchanged (layout presentation fix only).

### Testing and Reliability
- [ ] **Unit Testing**: Not added (UI rendering/layout change; recommend visual validation).
- [x] **Emulator and Real Device Testing**: Verified visually on affected trip details and trip preview header flows.

### Error Handling and Logging
- [x] **Error Handling**: No error-handling paths changed.
- [x] **Logging**: No logging changes required for this UI-only fix.

## Testing Procedure

If applicable, provide steps or commands for testing your changes. This can help reviewers and testers.

- Open a trip with service alerts and verify alert icons retain original multi-color appearance.
- Open trip details and confirm bus/transport segment icon is no longer single-color flattened.
- Open trip preview header and confirm transport icons (including bus) are not flattened when selected/unselected.