### PR TITLE
[25507] Align cycling speed with API 0–2

### DIFF
--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/routing/settings/CyclingSpeed.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/routing/settings/CyclingSpeed.kt
@@ -1,12 +1,17 @@
 package com.skedgo.tripkit.ui.routing.settings
 
 enum class CyclingSpeed(val value: Int) {
-    Slow(0), Medium(1), Fast(2), Impaired(-1)
+    Slow(0), Medium(1), Fast(2)
 }
 
+/**
+ * Maps stored preference values to cycling speed. Routing `cs` only supports 0–2;
+ * legacy `-1` ("impaired") is treated as [CyclingSpeed.Slow].
+ */
 fun Int.toCyclingSpeed(): CyclingSpeed = when (this) {
     0 -> CyclingSpeed.Slow
     1 -> CyclingSpeed.Medium
     2 -> CyclingSpeed.Fast
-    else -> CyclingSpeed.Impaired
+    -1 -> CyclingSpeed.Slow
+    else -> CyclingSpeed.Medium
 }

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/routing/settings/CyclingSpeedRepositoryImpl.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/routing/settings/CyclingSpeedRepositoryImpl.kt
@@ -19,6 +19,10 @@ internal class CyclingSpeedRepositoryImpl constructor(
 
     override fun getCyclingSpeed(): CyclingSpeed {
         val speed = prefs.getString(resources.getString(R.string.pref_cycling_speed), null)?.toInt()
+        if (speed == -1) {
+            putCyclingSpeed(CyclingSpeed.Slow)
+            return CyclingSpeed.Slow
+        }
         return speed?.toCyclingSpeed() ?: CyclingSpeed.Medium
     }
 }

--- a/TripKitAndroidUI/src/test/java/com/skedgo/tripkit/ui/routing/settings/CyclingSpeedRepositoryImplTest.kt
+++ b/TripKitAndroidUI/src/test/java/com/skedgo/tripkit/ui/routing/settings/CyclingSpeedRepositoryImplTest.kt
@@ -63,4 +63,15 @@ class CyclingSpeedRepositoryImplTest {
 
         assert(result == CyclingSpeed.Medium)
     }
+
+    @Test
+    fun `getCyclingSpeed should migrate legacy impaired -1 to Slow`() = runBlocking {
+        every { prefs.getString("pref_cycling_speed", null) } returns "-1"
+
+        val result = repository.getCyclingSpeed()
+
+        assert(result == CyclingSpeed.Slow)
+        verify { editor.putString("pref_cycling_speed", "0") }
+        verify { editor.apply() }
+    }
 }


### PR DESCRIPTION
## PR Context

- **Type**: Bug Fix
- **Issue Link**: [Redmine Issue](https://redmine.buzzhives.com/issues/25507)
- **Risk Factor**: Low - Cycling speed now follows the documented API contract (`cs` supports only `0`, `1`, `2`), with backward-safe migration for legacy `-1`.

## Changes

Updated cycling speed handling to remove unsupported impaired behavior while preserving existing user preferences safely during upgrade.

- Removed `Impaired` from `CyclingSpeed`; cycling now uses `Slow`, `Medium`, `Fast` only.
- Mapped legacy cycling value `-1` to `Slow` in `toCyclingSpeed()`.
- Added migration in `CyclingSpeedRepositoryImpl`: when stored value is `-1`, rewrite it to `0` and return `Slow`.
- Updated cycling speed selector in `TransportDetailsFragment` to show only 3 options (`Slow`, `Medium`, `Fast`).
- Added unit test verifying migration from `-1` to `0` in `CyclingSpeedRepositoryImplTest`.
- Updated parent repo submodule pointer to include the TripKit Android UI commit.

## Checklist for Reviewers

### Documentation and Code Quality
- [x] **KDocs Documentation**: Added targeted comment in `CyclingSpeed.kt` explaining why legacy `-1` maps to `Slow`.
- [x] **Architectural Patterns**: Existing architecture unchanged; fix is limited to settings model/repository and UI binding.

### Testing and Reliability
- [x] **Unit Testing**: Added migration test for legacy `-1` in `CyclingSpeedRepositoryImplTest`.
- [ ] **Emulator and Real Device Testing**: Pending manual validation in transport settings screen.

### Error Handling and Logging
- [x] **Error Handling**: Legacy invalid value is handled gracefully and normalized.
- [x] **Logging**: No new logging required for preference normalization path.