### PR TITLE
[25585] Align trip result service alerts with iOS behavior.

### DIFF
--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripSegmentItemViewModel.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripSegmentItemViewModel.kt
@@ -148,7 +148,7 @@ class TripSegmentItemViewModel @Inject internal constructor(
 
             segment.determineAndShowSegmentIcon(viewType, lineColor, tintWhite, segmentCircleColor)
 
-            segment.handleAlerts()
+            updateAlertStateForViewType(viewType, segment.alerts)
 
             _isHideExactTimes.postValue(segment.isHideExactTimes)
             if (!isStationaryItem) {
@@ -164,21 +164,28 @@ class TripSegmentItemViewModel @Inject internal constructor(
         }
     }
 
-    private fun TripSegment.handleAlerts() {
-        if (!this.alerts.isNullOrEmpty()) {
-            showAlerts.value = true
-            this.alerts?.groupConsecutiveBy { firstItem, secondItem ->
-                firstItem.title() == secondItem.title()
-            }?.let { sameTitleGroups ->
-                val alertsArray = ArrayList<RealtimeAlert>()
-                sameTitleGroups.forEach { group ->
-                    if (group.isNotEmpty()) {
-                        alertsArray.add(group.first())
-                    }
-                }
-                this@TripSegmentItemViewModel.alerts.value = alertsArray
+    @VisibleForTesting
+    internal fun updateAlertStateForViewType(
+        viewType: SegmentViewType,
+        alerts: List<RealtimeAlert>?
+    ) {
+        // iOS parity: service alerts are rendered for moving rows only.
+        if (viewType != SegmentViewType.MOVING || alerts.isNullOrEmpty()) {
+            showAlerts.value = false
+            this.alerts.value = arrayListOf()
+            return
+        }
+
+        showAlerts.value = true
+        val deduplicatedAlerts = arrayListOf<RealtimeAlert>()
+        alerts.groupConsecutiveBy { firstItem, secondItem ->
+            firstItem.title() == secondItem.title()
+        }.forEach { group ->
+            if (group.isNotEmpty()) {
+                deduplicatedAlerts.add(group.first())
             }
         }
+        this.alerts.value = deduplicatedAlerts
     }
 
     private fun TripSegment.determineAndShowSegmentIcon(

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripSegmentsViewModel.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripSegmentsViewModel.kt
@@ -680,6 +680,14 @@ class TripSegmentsViewModel @Inject internal constructor(
                         val bridgeModel = segmentViewModelProvider.get()
                         bridgeModel.tripSegment = segment
                         addMovingItem(bridgeModel, segment)
+                        bridgeModel.alertsClicked.subscribeWithErrorHandling {
+                            alertsClicked.accept(it)
+                        }.autoClear()
+
+                        bridgeModel.externalActionClicked.subscribeWithErrorHandling {
+                            externalActionClicked.accept(it)
+                        }.autoClear()
+
                         bridgeModel.onClick.observable.subscribeWithErrorHandling {
                             it.tripSegment?.let { segment ->
                                 segmentClicked.accept(segment)

--- a/TripKitAndroidUI/src/test/java/com/skedgo/tripkit/ui/tripresult/TripSegmentItemViewModelTest.kt
+++ b/TripKitAndroidUI/src/test/java/com/skedgo/tripkit/ui/tripresult/TripSegmentItemViewModelTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.Resources
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.core.content.ContextCompat
+import com.skedgo.tripkit.common.model.realtimealert.RealtimeAlert
 import com.skedgo.tripkit.datetime.PrintTime
 import com.skedgo.tripkit.routing.Occupancy
 import com.skedgo.tripkit.routing.RealTimeVehicle
@@ -23,6 +24,9 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -96,6 +100,40 @@ class TripSegmentItemViewModelTest : MockKTest() {
         every { mockTripSegment.realTimeVehicle } returns null
         viewModel.initOccupancy(mockTripSegment)
         verify(exactly = 0) { occupancyViewModel.setOccupancy(any(), any()) }
+    }
+
+    @Test
+    fun `updateAlertStateForViewType - shows deduplicated alerts for moving segment`() {
+        val firstAlert = mockk<RealtimeAlert>()
+        val duplicateFirstAlert = mockk<RealtimeAlert>()
+        val secondAlert = mockk<RealtimeAlert>()
+        every { firstAlert.title() } returns "Weekday track closure"
+        every { duplicateFirstAlert.title() } returns "Weekday track closure"
+        every { secondAlert.title() } returns "Other disruption"
+
+        viewModel.updateAlertStateForViewType(
+            TripSegmentItemViewModel.SegmentViewType.MOVING,
+            listOf(firstAlert, duplicateFirstAlert, secondAlert)
+        )
+
+        assertTrue(viewModel.showAlerts.value == true)
+        assertEquals(2, viewModel.alerts.value?.size)
+        assertEquals(firstAlert, viewModel.alerts.value?.first())
+        assertEquals(secondAlert, viewModel.alerts.value?.get(1))
+    }
+
+    @Test
+    fun `updateAlertStateForViewType - hides alerts for stationary bridge segment`() {
+        val alert = mockk<RealtimeAlert>()
+        every { alert.title() } returns "Weekday track closure"
+
+        viewModel.updateAlertStateForViewType(
+            TripSegmentItemViewModel.SegmentViewType.STATIONARY_BRIDGE,
+            listOf(alert)
+        )
+
+        assertFalse(viewModel.showAlerts.value == true)
+        assertTrue(viewModel.alerts.value?.isEmpty() == true)
     }
 
 }


### PR DESCRIPTION
## PR Context

- **Type**: Bug Fix
- **Issue Link**: [Redmine Issue](https://redmine.buzzhives.com/issues/25585)
- **Risk Factor**: Medium - UI behavior changed to enforce iOS parity for service alert rendering; could affect trip segment alert visibility/click behavior if not validated across segment combinations.

## Changes

Render service alerts only on moving segment rows to prevent duplicate cards, and ensure moving bridge models forward alert clicks correctly. Add tests for moving vs stationary-bridge alert visibility and deduplication.

- Updated `TripSegmentItemViewModel` to render alerts only for `SegmentViewType.MOVING`.
- Preserved and covered deduplication behavior for consecutive alerts with identical titles.
- Updated `TripSegmentsViewModel` to forward `alertsClicked` and `externalActionClicked` from moving `bridgeModel` rows.
- Added unit tests validating moving vs stationary-bridge alert visibility and alert deduplication behavior.

## Checklist for Reviewers

### Documentation and Code Quality
- [x] **KDocs Documentation**: Are all changes, new functionalities, and classes documented with KDocs?
- [x] **Architectural Patterns**: Is there consistent and proper use of architectural patterns (e.g., MVVM, MVP)?

### Testing and Reliability
- [x] **Unit Testing**: Are there unit tests for all new functionalities and classes?
- [ ] **Emulator and Real Device Testing**: Has the application been tested on both emulators and real devices to ensure compatibility?

### Error Handling and Logging
- [x] **Error Handling**: Are errors and exceptions caught and handled gracefully, ensuring the app remains stable?
- [ ] **Logging**: Is there proper logging in place for critical errors and information, aiding in debugging and monitoring?