### PR TITLE
[25413] Fix TimetableMapContributor Handler cleanup to prevent memory leaks

### DIFF
--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/timetables/TimetableMapContributor.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/timetables/TimetableMapContributor.kt
@@ -60,7 +60,14 @@ import timber.log.Timber
 import java.util.Collections
 import javax.inject.Inject
 
-
+/**
+ * Map contributor for timetable / service-detail screens.
+ *
+ * Draws service stops, route polylines, and a real-time vehicle marker with periodic fade updates.
+ * A main-thread [Handler] drives the fade loop; [cleanup] must be invoked (via [TripKitMapContributor]
+ * or fragment destruction) so pending callbacks are cleared and the contributor does not outlive
+ * its host fragment.
+ */
 class TimetableMapContributor(val fragment: Fragment) : TripKitMapContributor {
     protected val autoDisposable: CompositeDisposable by lazy {
         CompositeDisposable()
@@ -101,7 +108,11 @@ class TimetableMapContributor(val fragment: Fragment) : TripKitMapContributor {
 
     private var pulseOverlay: GroundOverlay? = null
 
+    /** Schedules real-time vehicle marker fade updates on the main looper. Cleared in [cleanup]. */
     private val handler = Handler(Looper.getMainLooper())
+
+    /** When false, [fadeRunnable] will not reschedule itself (e.g. after [cleanup]). */
+    private var markerUpdatesActive = false
 
     override fun initialize() {
         TripKitUI.getInstance()
@@ -127,6 +138,7 @@ class TimetableMapContributor(val fragment: Fragment) : TripKitMapContributor {
 
     private val fadeRunnable = object : Runnable {
         override fun run() {
+            if (!markerUpdatesActive) return
             updateVehicleMarkerAppearance()
             handler.postDelayed(this, 1000) // Schedule next update after 1 second
         }
@@ -212,9 +224,13 @@ class TimetableMapContributor(val fragment: Fragment) : TripKitMapContributor {
     }
 
     override fun cleanup() {
-        stopMarkerUpdateInterval() // Stop periodic updates
+        stopMarkerUpdateInterval()
+        googleMap?.setOnCameraIdleListener(null)
+        googleMap = null
         stopCodesToMarkerMap.forEach { it.value.remove() }
+        stopCodesToMarkerMap.clear()
         serviceLines.forEach { it.remove() }
+        serviceLines.clear()
         autoDisposable.clear()
         cleanupServiceDetailVehicleUpdates()
     }
@@ -423,16 +439,24 @@ class TimetableMapContributor(val fragment: Fragment) : TripKitMapContributor {
 
     /**
      * Starts the periodic updates for marker fading and snippet updates.
+     *
+     * Cancels any existing fade loop first so [safeToUseMap] can be called more than once
+     * without stacking multiple [Handler] runnables.
      */
     private fun startMarkerUpdateInterval() {
-        // Delay the first execution to avoid immediate update showing "1 second ago" twice
+        stopMarkerUpdateInterval()
+        markerUpdatesActive = true
         handler.postDelayed(fadeRunnable, 1000) // 1-second delay
     }
 
     /**
      * Stops the periodic updates for marker fading and snippet updates.
+     *
+     * Removes all pending callbacks and messages on [handler] so it cannot retain this
+     * contributor after [cleanup] or contributor switching.
      */
     private fun stopMarkerUpdateInterval() {
+        markerUpdatesActive = false
         handler.removeCallbacks(fadeRunnable)
     }
 


### PR DESCRIPTION
## PR Context

- **Type**: Bug Fix
- **Issue Link**: [Redmine Issue](https://redmine.buzzhives.com/issues/25413)
- **Risk Factor**: Low — changes are isolated to `TimetableMapContributor`. Fade timing and all existing behavior are preserved; only the cleanup path is strengthened.

## Changes

Fixes `TimetableMapContributor` so its `Handler` and associated state cannot outlive the host fragment, eliminating a potential memory leak on API 30+ devices.

- `stopMarkerUpdateInterval()` is now the single, consistent place where the handler is drained.
- **`markerUpdatesActive` guard in `fadeRunnable`**: prevents `fadeRunnable` from rescheduling itself via `postDelayed` in the window between `cleanup()` disabling the flag and the runnable executing (defensive invariant; main-thread looper guarantees no true concurrency here).
- **Idempotent `startMarkerUpdateInterval()`**: calls `stopMarkerUpdateInterval()` first so repeated `safeToUseMap` calls (e.g. contributor reuse) cannot stack multiple concurrent fade loops.
- **Broader `cleanup()`**: clears the `OnCameraIdleListener` and nulls `googleMap` before removing markers; calls `.clear()` on `stopCodesToMarkerMap` and `serviceLines` after removing their map objects to release all stale SDK references.
- **KDoc**: added class-level KDoc, field-level KDoc for `handler` and `markerUpdatesActive`, and updated KDoc on `startMarkerUpdateInterval` / `stopMarkerUpdateInterval`.

## Checklist for Reviewers

### Documentation and Code Quality
- [x] **KDocs Documentation**: Class, handler field, flag, and interval methods are documented with KDocs.
- [x] **Architectural Patterns**: No architectural change; contributor pattern (MVVM + `TripKitMapContributor`) is unchanged.

### Testing and Reliability
- [ ] **Unit Testing**: No new unit tests added — contributor relies on Google Maps SDK objects that require instrumentation tests.
- [ ] **Emulator and Real Device Testing**: Verify on emulator and real device (see Testing Procedure).

### Error Handling and Logging
- [x] **Error Handling**: All SDK calls remain guarded (`googleMap?.`, null-safe marker removal). No new failure paths introduced.
- [x] **Logging**: Existing `Timber` logging retained; no new log noise added.

## Testing Procedure

- Open the **service detail / timetable** screen for any service that has real-time vehicle data. Confirm the vehicle marker fades correctly over time and the elapsed-time label updates every second.
- **Contributor switch**: navigate into service detail, then back to the timetable list, and back into a different service. Confirm no crash and no stale markers remain on the map.
- **LeakCanary** (API 30+ device or emulator): navigate into and out of service detail several times. Confirm no `Handler` or `TimetableMapContributor` leaks are reported.
- **TalkBack** (optional): verify accessibility focus on the service detail screen is unaffected.
