### PR TITLE
[24554][25966][25964][25631] Fix map/trip memory pressure, OOM crashes, and related UI stability issues

### DIFF
--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/core/StopsPersistor.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/core/StopsPersistor.kt
@@ -28,7 +28,7 @@ class StopsPersistor @Inject constructor(
     }
 
     override fun saveStopsSync(cells: List<LocationsResponse.Group>) {
-        Timber.i("DEBUG: StopsPersistor.saveStopsSync called with ${cells.size} cells")
+        // Timber.i("DEBUG: StopsPersistor.saveStopsSync called with ${cells.size} cells")
 
         val regionalSourceStopCodes = collectRegionalSourceStopCodes(cells)
         if (regionalSourceStopCodes.isNotEmpty()) {
@@ -48,10 +48,10 @@ class StopsPersistor @Inject constructor(
         for (cell in cells) {
             val cellId = cell.key
             val stops = cell.stops
-            Timber.i("DEBUG: Processing cell: $cellId with ${stops?.size ?: 0} stops")
+            // Timber.i("DEBUG: Processing cell: $cellId with ${stops?.size ?: 0} stops")
             
             if (cellId.isNullOrEmpty() || stops.isNullOrEmpty()) {
-                Timber.i("DEBUG: Skipping cell $cellId - empty or null")
+                // Timber.i("DEBUG: Skipping cell $cellId - empty or null")
                 continue
             }
 
@@ -64,7 +64,7 @@ class StopsPersistor @Inject constructor(
             )
         }
 
-        Timber.i("DEBUG: Created ${scheduledStops.size} scheduled stops and ${locations.size} locations")
+        // Timber.i("DEBUG: Created ${scheduledStops.size} scheduled stops and ${locations.size} locations")
 
         val coreCount = Runtime.getRuntime().availableProcessors()
         val sleepTime = when {
@@ -74,9 +74,9 @@ class StopsPersistor @Inject constructor(
         }
 
         if (scheduledStops.isNotEmpty() && locations.isNotEmpty()) {
-            Timber.i("DEBUG: Starting batch insertion")
+            // Timber.i("DEBUG: Starting batch insertion")
             insertInBatches(scheduledStops, locations, sleepTime)
-            Timber.i("DEBUG: Batch insertion completed")
+            // Timber.i("DEBUG: Batch insertion completed")
         } else {
             Timber.i("DEBUG: No data to insert - scheduledStops: ${scheduledStops.size}, locations: ${locations.size}")
         }
@@ -136,11 +136,11 @@ class StopsPersistor @Inject constructor(
                 )
                 
                 // Debug: Print the actual coordinate values being stored
-                Timber.i("DEBUG: Creating LocationEntity for stop $stopCode:")
-                Timber.i("  - lat: ${stop.lat}")
-                Timber.i("  - lon: ${stop.lon}")
-                Timber.i("  - name: ${stop.name}")
-                Timber.i("  - address: ${stop.address}")
+                // Timber.i("DEBUG: Creating LocationEntity for stop $stopCode:")
+                // Timber.i("  - lat: ${stop.lat}")
+                // Timber.i("  - lon: ${stop.lon}")
+                // Timber.i("  - name: ${stop.name}")
+                // Timber.i("  - address: ${stop.address}")
                 
                 locations.add(parentLocationEntity)
 

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/database/scheduled_stops/LocationEntity.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/database/scheduled_stops/LocationEntity.kt
@@ -7,7 +7,7 @@ import androidx.room.PrimaryKey
 @Entity(
     tableName = "locations",
     indices = [
-        Index(value = ["scheduledStopCode"]),
+        Index(value = ["scheduledStopCode"], unique = true),
         Index(value = ["lat", "lon"]),
         Index(value = ["favouriteSortOrderPosition"])
     ]

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/database/scheduled_stops/ScheduledStopDatabase.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/database/scheduled_stops/ScheduledStopDatabase.kt
@@ -13,7 +13,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LocationEntity::class,
         ScheduledStopDownloadHistoryEntity::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = false
 )
 abstract class ScheduledStopDatabase : RoomDatabase() {
@@ -28,6 +28,34 @@ abstract class ScheduledStopDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    DELETE FROM locations
+                    WHERE scheduledStopCode IS NOT NULL
+                    AND id NOT IN (
+                        SELECT MAX(id)
+                        FROM locations
+                        WHERE scheduledStopCode IS NOT NULL
+                        GROUP BY scheduledStopCode
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    DELETE FROM locations
+                    WHERE scheduledStopCode IS NULL
+                    OR scheduledStopCode NOT IN (SELECT code FROM scheduled_stops)
+                    """.trimIndent()
+                )
+                db.execSQL("DROP INDEX IF EXISTS index_locations_scheduledStopCode")
+                db.execSQL(
+                    "CREATE UNIQUE INDEX index_locations_scheduledStopCode ON locations(scheduledStopCode)"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): ScheduledStopDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -35,7 +63,7 @@ abstract class ScheduledStopDatabase : RoomDatabase() {
                     ScheduledStopDatabase::class.java,
                     "scheduled_stop_database"
                 )
-                    .addMigrations(MIGRATION_1_2)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_3_4)
                     .fallbackToDestructiveMigration(true)
                     .build()
                 INSTANCE = instance

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/favorites/waypoints/Waypoint.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/favorites/waypoints/Waypoint.kt
@@ -51,7 +51,7 @@ data class Waypoint(
             try {
                 val mode = segment.getModeForWayPoint()
                 var vehicleUUID: String? = null
-                segment.realTimeVehicle?.id?.let {
+                segment.realTimeVehicle?.id?.takeIf { it > 0 }?.let {
                     vehicleUUID = it.toString()
                 }
 

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/RemoteMarkerIconFetcher.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/RemoteMarkerIconFetcher.kt
@@ -41,6 +41,14 @@ class RemoteMarkerIconFetcher @Inject constructor(
         private val descriptorCacheLock = Any()
         private val descriptorCache =
             LruCache<MarkerIconDescriptorCacheKey, BitmapDescriptor>(DESCRIPTOR_CACHE_MAX_ENTRIES)
+
+        // Coalesces concurrent requests for the same icon so a burst of markers
+        // sharing an icon (e.g. many-segment routes) decodes the bitmap once
+        // instead of once per marker, avoiding the allocation spike that triggers
+        // blocking-GC ANRs / OOM.
+        private val inFlightLock = Any()
+        private val inFlightRequests =
+            HashMap<MarkerIconDescriptorCacheKey, Single<BitmapDescriptor>>()
     }
 
     fun call(markerOptions: MarkerOptions, modeInfo: ModeInfo?) {
@@ -82,15 +90,43 @@ class RemoteMarkerIconFetcher @Inject constructor(
             }
 
             TripGoMapMarkerDiag.recordBitmapDescriptorCacheMiss(descriptorCacheSize())
-            Single.create { emitter ->
+            loadRemoteDescriptor(cacheKey, iconUrl, tintColor, circleColor)
+                .map { icon ->
+                    markerOptions.icon(icon)
+                    markerOptions
+                }
+                .onErrorResumeNext {
+                    // Fallback to local resource-based marker icon
+                    getMapIconFromResource(markerOptions, stop.type, densityDpiName)
+                }
+        }.subscribeOn(AndroidSchedulers.mainThread())
+    }
+
+    /**
+     * Returns a shared [Single] that decodes the remote icon and builds a
+     * [BitmapDescriptor] exactly once per [cacheKey]. Concurrent callers reuse the
+     * same in-flight request (or the cached descriptor), so a burst of markers
+     * sharing an icon no longer spawns one Picasso decode + multiple bitmap
+     * allocations per marker.
+     */
+    private fun loadRemoteDescriptor(
+        cacheKey: MarkerIconDescriptorCacheKey,
+        iconUrl: String?,
+        tintColor: Int,
+        circleColor: Int
+    ): Single<BitmapDescriptor> {
+        synchronized(inFlightLock) {
+            getCachedDescriptor(cacheKey)?.let { return Single.just(it) }
+            inFlightRequests[cacheKey]?.let { return it }
+
+            val request = Single.create<BitmapDescriptor> { emitter ->
                 picasso.load(iconUrl)
                     .into(object : com.squareup.picasso.Target {
                         override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
                             bitmap?.let {
                                 getCachedDescriptor(cacheKey)?.let { cachedIcon ->
                                     TripGoMapMarkerDiag.recordBitmapDescriptorCacheHit(descriptorCacheSize())
-                                    markerOptions.icon(cachedIcon)
-                                    emitter.onSuccess(markerOptions)
+                                    emitter.onSuccess(cachedIcon)
                                     return
                                 }
 
@@ -105,8 +141,7 @@ class RemoteMarkerIconFetcher @Inject constructor(
                                 TripGoMapMarkerDiag.recordBitmapDescriptorFromBitmap()
                                 putCachedDescriptor(cacheKey, icon)
                                 markerBitmap.recycleOwnedBitmaps()
-                                markerOptions.icon(icon)
-                                emitter.onSuccess(markerOptions)
+                                emitter.onSuccess(icon)
                             } ?: run {
                                 emitter.onError(Throwable("Bitmap is null"))
                             }
@@ -123,11 +158,16 @@ class RemoteMarkerIconFetcher @Inject constructor(
                             // Placeholder if needed
                         }
                     })
-            }.onErrorResumeNext {
-                // Fallback to local resource-based marker icon
-                getMapIconFromResource(markerOptions, stop.type, densityDpiName)
             }
-        }.subscribeOn(AndroidSchedulers.mainThread())
+                .doFinally {
+                    synchronized(inFlightLock) { inFlightRequests.remove(cacheKey) }
+                }
+                .subscribeOn(AndroidSchedulers.mainThread())
+                .cache()
+
+            inFlightRequests[cacheKey] = request
+            return request
+        }
     }
 
     private fun getMapIconFromResource(

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/RemoteMarkerIconFetcher.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/RemoteMarkerIconFetcher.kt
@@ -8,6 +8,7 @@ import android.graphics.PorterDuff
 import android.graphics.PorterDuff.Mode.SRC_IN
 import android.graphics.PorterDuffColorFilter
 import android.graphics.drawable.Drawable
+import android.util.LruCache
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.android.gms.maps.model.MarkerOptions
@@ -32,6 +33,14 @@ class RemoteMarkerIconFetcher @Inject constructor(
     companion object {
         const val SIZE_CIRCULAR_BITMAP = 30
         const val TINT_BITMAP_RGB = 255
+
+        private const val DESCRIPTOR_CACHE_MAX_ENTRIES = 200
+        private const val CACHE_SOURCE_REMOTE = "remote"
+        private const val CACHE_SOURCE_RESOURCE = "resource"
+        private const val CACHE_SOURCE_DEFAULT = "default"
+        private val descriptorCacheLock = Any()
+        private val descriptorCache =
+            LruCache<MarkerIconDescriptorCacheKey, BitmapDescriptor>(DESCRIPTOR_CACHE_MAX_ENTRIES)
     }
 
     fun call(markerOptions: MarkerOptions, modeInfo: ModeInfo?) {
@@ -43,30 +52,59 @@ class RemoteMarkerIconFetcher @Inject constructor(
 
     fun callAsync(markerOptions: MarkerOptions, stop: ScheduledStop): Single<MarkerOptions> {
         val modeInfo = stop.modeInfo
+        val densityDpiName = DeviceInfo.getDensityDpiName()
         val iconUrl =
             if(modeInfo?.remoteIconIsTemplate == true) {
-                getRemoteMapIconUrlForModeInfo(DeviceInfo.getDensityDpiName(), modeInfo)
+                getRemoteMapIconUrlForModeInfo(densityDpiName, modeInfo)
             } else {
-                getLocalMapIconUrlForModeInfo(DeviceInfo.getDensityDpiName(), modeInfo)
+                getLocalMapIconUrlForModeInfo(densityDpiName, modeInfo)
             }
+        val tintColor = Color.rgb(TINT_BITMAP_RGB, TINT_BITMAP_RGB, TINT_BITMAP_RGB)
+        val circleColor = Color.rgb(
+            modeInfo?.getServiceColor()?.red ?: 0,
+            modeInfo?.getServiceColor()?.green ?: 0,
+            modeInfo?.getServiceColor()?.blue ?: 0
+        )
+        val cacheKey = MarkerIconDescriptorCacheKey(
+            source = CACHE_SOURCE_REMOTE,
+            sourceId = iconUrl.orEmpty(),
+            densityDpiName = densityDpiName,
+            circleRadius = SIZE_CIRCULAR_BITMAP,
+            tintColor = tintColor,
+            circleColor = circleColor
+        )
+        TripGoMapMarkerDiag.recordIconFetch()
         return Single.defer {
+            getCachedDescriptor(cacheKey)?.let { cachedIcon ->
+                TripGoMapMarkerDiag.recordBitmapDescriptorCacheHit(descriptorCacheSize())
+                markerOptions.icon(cachedIcon)
+                return@defer Single.just(markerOptions)
+            }
+
+            TripGoMapMarkerDiag.recordBitmapDescriptorCacheMiss(descriptorCacheSize())
             Single.create { emitter ->
                 picasso.load(iconUrl)
                     .into(object : com.squareup.picasso.Target {
                         override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
                             bitmap?.let {
-                                val circularBitmap = createCircularMarkerBitmap(
+                                getCachedDescriptor(cacheKey)?.let { cachedIcon ->
+                                    TripGoMapMarkerDiag.recordBitmapDescriptorCacheHit(descriptorCacheSize())
+                                    markerOptions.icon(cachedIcon)
+                                    emitter.onSuccess(markerOptions)
+                                    return
+                                }
+
+                                val markerBitmap = createCircularMarkerBitmap(
                                     it,
-                                    Color.rgb(TINT_BITMAP_RGB, TINT_BITMAP_RGB, TINT_BITMAP_RGB),
-                                    Color.rgb(
-                                        modeInfo?.getServiceColor()?.red ?: 0,
-                                        modeInfo?.getServiceColor()?.green ?: 0,
-                                        modeInfo?.getServiceColor()?.blue ?: 0
-                                    ),
+                                    tintColor,
+                                    circleColor,
                                     SIZE_CIRCULAR_BITMAP
                                 )
 
-                                val icon = BitmapDescriptorFactory.fromBitmap(circularBitmap)
+                                val icon = BitmapDescriptorFactory.fromBitmap(markerBitmap.bitmap)
+                                TripGoMapMarkerDiag.recordBitmapDescriptorFromBitmap()
+                                putCachedDescriptor(cacheKey, icon)
+                                markerBitmap.recycleOwnedBitmaps()
                                 markerOptions.icon(icon)
                                 emitter.onSuccess(markerOptions)
                             } ?: run {
@@ -87,19 +125,39 @@ class RemoteMarkerIconFetcher @Inject constructor(
                     })
             }.onErrorResumeNext {
                 // Fallback to local resource-based marker icon
-                getMapIconFromResource(markerOptions, stop.type)
+                getMapIconFromResource(markerOptions, stop.type, densityDpiName)
             }
         }.subscribeOn(AndroidSchedulers.mainThread())
     }
 
-    private fun getMapIconFromResource(markerOptions: MarkerOptions, type: StopType?): Single<MarkerOptions> {
+    private fun getMapIconFromResource(
+        markerOptions: MarkerOptions,
+        type: StopType?,
+        densityDpiName: String
+    ): Single<MarkerOptions> {
         return Single.fromCallable {
             val iconRes = BindingConversions.convertStopTypeToMapIconRes(type)
+            val cacheKey = MarkerIconDescriptorCacheKey(
+                source = if (iconRes == 0) CACHE_SOURCE_DEFAULT else CACHE_SOURCE_RESOURCE,
+                sourceId = iconRes.toString(),
+                densityDpiName = densityDpiName,
+                circleRadius = 0,
+                tintColor = 0,
+                circleColor = 0
+            )
+            getCachedDescriptor(cacheKey)?.let { cachedIcon ->
+                TripGoMapMarkerDiag.recordBitmapDescriptorCacheHit(descriptorCacheSize())
+                markerOptions.icon(cachedIcon)
+                return@fromCallable markerOptions
+            }
+
+            TripGoMapMarkerDiag.recordBitmapDescriptorCacheMiss(descriptorCacheSize())
             val icon: BitmapDescriptor = if (iconRes == 0) {
                 BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_YELLOW)
             } else {
                 BitmapDescriptorFactory.fromResource(iconRes)
             }
+            putCachedDescriptor(cacheKey, icon)
             markerOptions.icon(icon)
             markerOptions
         }
@@ -110,9 +168,10 @@ class RemoteMarkerIconFetcher @Inject constructor(
         tintColor: Int,
         circleColor: Int,
         circleRadius: Int
-    ): Bitmap {
+    ): CreatedMarkerBitmap {
         // Create a new bitmap for the output
         val output = Bitmap.createBitmap(circleRadius * 2, circleRadius * 2, Bitmap.Config.ARGB_8888)
+        TripGoMapMarkerDiag.recordBitmapCreation()
         val canvas = Canvas(output)
 
         // Draw the white border
@@ -133,6 +192,7 @@ class RemoteMarkerIconFetcher @Inject constructor(
 
         // Apply tint to the bitmap
         val tintedBitmap = bitmap.copy(Bitmap.Config.ARGB_8888, true)
+        TripGoMapMarkerDiag.recordBitmapCreation(scaleOrCopy = 1)
         val bitmapCanvas = Canvas(tintedBitmap)
         val tintPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             colorFilter = PorterDuffColorFilter(tintColor, PorterDuff.Mode.SRC_IN)
@@ -163,12 +223,67 @@ class RemoteMarkerIconFetcher @Inject constructor(
             targetHeight,
             true
         )
+        TripGoMapMarkerDiag.recordBitmapCreation(scaleOrCopy = 1)
 
         // Draw the scaled bitmap at the center of the circular background
         val left = (output.width - scaledBitmap.width) / 2f
         val top = (output.height - scaledBitmap.height) / 2f
         canvas.drawBitmap(scaledBitmap, left, top, null)
 
-        return output
+        return CreatedMarkerBitmap(
+            bitmap = output,
+            sourceBitmap = bitmap,
+            tintedBitmap = tintedBitmap,
+            scaledBitmap = scaledBitmap
+        )
     }
+
+    private fun getCachedDescriptor(key: MarkerIconDescriptorCacheKey): BitmapDescriptor? =
+        synchronized(descriptorCacheLock) {
+            descriptorCache.get(key)
+        }
+
+    private fun putCachedDescriptor(key: MarkerIconDescriptorCacheKey, descriptor: BitmapDescriptor) {
+        synchronized(descriptorCacheLock) {
+            descriptorCache.put(key, descriptor)
+        }
+    }
+
+    private fun descriptorCacheSize(): Int =
+        synchronized(descriptorCacheLock) {
+            descriptorCache.size()
+        }
+
+    private data class CreatedMarkerBitmap(
+        val bitmap: Bitmap,
+        val sourceBitmap: Bitmap,
+        val tintedBitmap: Bitmap,
+        val scaledBitmap: Bitmap
+    ) {
+        fun recycleOwnedBitmaps() {
+            // Picasso owns the source bitmap. Only recycle bitmaps allocated in this class.
+            recycleIfOwned(scaledBitmap)
+            recycleIfOwned(tintedBitmap)
+            recycleIfOwned(bitmap)
+        }
+
+        private fun recycleIfOwned(candidate: Bitmap) {
+            if (
+                candidate !== sourceBitmap &&
+                !candidate.isRecycled
+            ) {
+                candidate.recycle()
+                TripGoMapMarkerDiag.recordBitmapRecycle()
+            }
+        }
+    }
+
+    internal data class MarkerIconDescriptorCacheKey(
+        val source: String,
+        val sourceId: String,
+        val densityDpiName: String,
+        val circleRadius: Int,
+        val tintColor: Int,
+        val circleColor: Int
+    )
 }

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/RemoteMarkerIconFetcher.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/RemoteMarkerIconFetcher.kt
@@ -21,6 +21,7 @@ import com.skedgo.tripkit.ui.utils.DeviceInfo
 import com.skedgo.tripkit.ui.utils.StopMarkerUtils.getLocalMapIconUrlForModeInfo
 import com.skedgo.tripkit.ui.utils.StopMarkerUtils.getRemoteMapIconUrlForModeInfo
 import com.squareup.picasso.Picasso
+import com.squareup.picasso.Target
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import java.lang.ref.WeakReference
@@ -49,6 +50,8 @@ class RemoteMarkerIconFetcher @Inject constructor(
         private val inFlightLock = Any()
         private val inFlightRequests =
             HashMap<MarkerIconDescriptorCacheKey, Single<BitmapDescriptor>>()
+        private val inFlightTargets =
+            HashMap<MarkerIconDescriptorCacheKey, Target>()
     }
 
     fun call(markerOptions: MarkerOptions, modeInfo: ModeInfo?) {
@@ -120,47 +123,56 @@ class RemoteMarkerIconFetcher @Inject constructor(
             inFlightRequests[cacheKey]?.let { return it }
 
             val request = Single.create<BitmapDescriptor> { emitter ->
+                val target = object : Target {
+                    override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
+                        bitmap?.let {
+                            getCachedDescriptor(cacheKey)?.let { cachedIcon ->
+                                TripGoMapMarkerDiag.recordBitmapDescriptorCacheHit(descriptorCacheSize())
+                                emitter.onSuccess(cachedIcon)
+                                return
+                            }
+
+                            val markerBitmap = createCircularMarkerBitmap(
+                                it,
+                                tintColor,
+                                circleColor,
+                                SIZE_CIRCULAR_BITMAP
+                            )
+
+                            val icon = BitmapDescriptorFactory.fromBitmap(markerBitmap.bitmap)
+                            TripGoMapMarkerDiag.recordBitmapDescriptorFromBitmap()
+                            putCachedDescriptor(cacheKey, icon)
+                            markerBitmap.recycleOwnedBitmaps()
+                            emitter.onSuccess(icon)
+                        } ?: run {
+                            emitter.onError(Throwable("Bitmap is null"))
+                        }
+                    }
+
+                    override fun onBitmapFailed(e: Exception?, errorDrawable: Drawable?) {
+                        if(BuildConfig.DEBUG) {
+                            e?.printStackTrace()
+                        }
+                        emitter.onError(e ?: Throwable("Bitmap failed to load"))
+                    }
+
+                    override fun onPrepareLoad(placeHolderDrawable: Drawable?) {
+                        // Placeholder if needed
+                    }
+                }
+                // Picasso keeps Target instances weakly. Retain this target until the
+                // shared request terminates so its callback can complete the Single.
+                synchronized(inFlightLock) {
+                    inFlightTargets[cacheKey] = target
+                }
                 picasso.load(iconUrl)
-                    .into(object : com.squareup.picasso.Target {
-                        override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
-                            bitmap?.let {
-                                getCachedDescriptor(cacheKey)?.let { cachedIcon ->
-                                    TripGoMapMarkerDiag.recordBitmapDescriptorCacheHit(descriptorCacheSize())
-                                    emitter.onSuccess(cachedIcon)
-                                    return
-                                }
-
-                                val markerBitmap = createCircularMarkerBitmap(
-                                    it,
-                                    tintColor,
-                                    circleColor,
-                                    SIZE_CIRCULAR_BITMAP
-                                )
-
-                                val icon = BitmapDescriptorFactory.fromBitmap(markerBitmap.bitmap)
-                                TripGoMapMarkerDiag.recordBitmapDescriptorFromBitmap()
-                                putCachedDescriptor(cacheKey, icon)
-                                markerBitmap.recycleOwnedBitmaps()
-                                emitter.onSuccess(icon)
-                            } ?: run {
-                                emitter.onError(Throwable("Bitmap is null"))
-                            }
-                        }
-
-                        override fun onBitmapFailed(e: Exception?, errorDrawable: Drawable?) {
-                            if(BuildConfig.DEBUG) {
-                                e?.printStackTrace()
-                            }
-                            emitter.onError(e ?: Throwable("Bitmap failed to load"))
-                        }
-
-                        override fun onPrepareLoad(placeHolderDrawable: Drawable?) {
-                            // Placeholder if needed
-                        }
-                    })
+                    .into(target)
             }
                 .doFinally {
-                    synchronized(inFlightLock) { inFlightRequests.remove(cacheKey) }
+                    synchronized(inFlightLock) {
+                        inFlightRequests.remove(cacheKey)
+                        inFlightTargets.remove(cacheKey)
+                    }
                 }
                 .subscribeOn(AndroidSchedulers.mainThread())
                 .cache()

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/ScheduledStopRepository.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/ScheduledStopRepository.kt
@@ -47,7 +47,13 @@ open class ScheduledStopRepository @Inject constructor(
             result
         }
 
-        return scheduledStopMapper.mapToDomainList(entities)
+        val stops = scheduledStopMapper.mapToDomainList(entities)
+        TripGoMapMarkerDiag.recordDbQuery(
+            cellCount = cellCodes.size,
+            returnedStopCount = stops.size,
+            usedBounds = bounds != null
+        )
+        return stops
     }
 
     fun queryStops(

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/ScheduledStopRepository.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/ScheduledStopRepository.kt
@@ -132,12 +132,17 @@ open class ScheduledStopRepository @Inject constructor(
      */
     fun deleteByCellCodesSync(cellCodes: List<String>) {
         if (cellCodes.isEmpty()) return
-        
-        // Delete in single transaction via Room - efficient for bulk operations
-        val deletedStops = scheduledStopDatabase.scheduledStopDao().deleteScheduledStopsByCellCodes(cellCodes)
-        val deletedLocations = scheduledStopDatabase.scheduledStopDao().deleteLocationsByCellCodes(cellCodes)
-        
-        Timber.d("Deleted old data for ${cellCodes.size} cells: $deletedStops stops, $deletedLocations locations")
+
+        scheduledStopDatabase.runInTransaction {
+            // Locations must be deleted before stops: location delete uses a subquery on scheduled_stops.
+            val deletedLocations =
+                scheduledStopDatabase.scheduledStopDao().deleteLocationsByCellCodes(cellCodes)
+            val deletedStops =
+                scheduledStopDatabase.scheduledStopDao().deleteScheduledStopsByCellCodes(cellCodes)
+            Timber.d(
+                "Deleted old data for ${cellCodes.size} cells: $deletedStops stops, $deletedLocations locations"
+            )
+        }
     }
 
     fun update(
@@ -379,4 +384,5 @@ open class ScheduledStopRepository @Inject constructor(
             isDynamic = isDynamic
         )
     }
+
 }

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/TripGoMapMarkerDiag.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/TripGoMapMarkerDiag.kt
@@ -1,0 +1,236 @@
+package com.skedgo.tripkit.ui.map
+
+import android.os.Debug
+import com.google.maps.android.collections.MarkerManager
+import timber.log.Timber
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+internal object TripGoMapMarkerDiag {
+    const val DEBUG_MAP_MARKER_RESOURCE_COUNTERS = false
+
+    private const val TAG = "TripGoMapMarkerDiag"
+    private const val MIN_LOG_INTERVAL_MS = 2_000L
+    private val fdThresholds = intArrayOf(300, 500, 800, 1000, 1500)
+
+    private val nextFdThresholdIndex = AtomicInteger(0)
+    private val lastLogAtMs = AtomicLong(0L)
+
+    private val cameraEvents = AtomicLong(0L)
+    private val cameraIdleEvents = AtomicLong(0L)
+    private val markerEmissions = AtomicLong(0L)
+    private val markerRenderBatches = AtomicLong(0L)
+    private val markersAdded = AtomicLong(0L)
+    private val markersRemoved = AtomicLong(0L)
+    private val markersHidden = AtomicLong(0L)
+    private val markersShown = AtomicLong(0L)
+    private val iconFetchCalls = AtomicLong(0L)
+    private val bitmapCreations = AtomicLong(0L)
+    private val bitmapScaleOrCopy = AtomicLong(0L)
+    private val bitmapRecycles = AtomicLong(0L)
+    private val bitmapDescriptorsFromBitmap = AtomicLong(0L)
+    private val bitmapDescriptorCacheHits = AtomicLong(0L)
+    private val bitmapDescriptorCacheMisses = AtomicLong(0L)
+    private val dbQueries = AtomicLong(0L)
+    private val locationFetches = AtomicLong(0L)
+
+    fun isEnabled(): Boolean = DEBUG_MAP_MARKER_RESOURCE_COUNTERS
+
+    fun recordCameraEvent() {
+        if (!DEBUG_MAP_MARKER_RESOURCE_COUNTERS) return
+        cameraEvents.incrementAndGet()
+    }
+
+    fun recordCameraIdle(snapshot: MarkerSnapshot) {
+        if (!DEBUG_MAP_MARKER_RESOURCE_COUNTERS) return
+        val count = cameraIdleEvents.incrementAndGet()
+        maybeLog("cameraIdle event=idle cameraIdle=$count ${snapshot.format()}")
+    }
+
+    fun recordMarkerBatch(
+        newMarkerOptions: Int,
+        removedIds: Int,
+        added: Int,
+        removed: Int,
+        snapshot: MarkerSnapshot
+    ) {
+        if (!DEBUG_MAP_MARKER_RESOURCE_COUNTERS) return
+        markerEmissions.incrementAndGet()
+        val batch = markerRenderBatches.incrementAndGet()
+        markersAdded.addAndGet(added.toLong())
+        markersRemoved.addAndGet(removed.toLong())
+        maybeLog(
+            "markerBatch event=render batch=$batch options=$newMarkerOptions removedIds=$removedIds " +
+                "added=$added removed=$removed ${snapshot.format()}"
+        )
+    }
+
+    fun recordMarkerVisibility(hidden: Int, shown: Int, snapshot: MarkerSnapshot) {
+        if (!DEBUG_MAP_MARKER_RESOURCE_COUNTERS) return
+        markersHidden.addAndGet(hidden.toLong())
+        markersShown.addAndGet(shown.toLong())
+        maybeLog("markerViewport event=hideViewport hidden=$hidden shown=$shown ${snapshot.format()}")
+    }
+
+    fun recordMarkerCleanup(event: String, before: Int, after: Int, snapshot: MarkerSnapshot) {
+        if (!DEBUG_MAP_MARKER_RESOURCE_COUNTERS) return
+        maybeLog("markerCleanup event=$event before=$before after=$after ${snapshot.format()}")
+    }
+
+    fun recordIconFetch() {
+        if (!DEBUG_MAP_MARKER_RESOURCE_COUNTERS) return
+        iconFetchCalls.incrementAndGet()
+    }
+
+    fun recordBitmapCreation(created: Int = 1, scaleOrCopy: Int = 0) {
+        if (!DEBUG_MAP_MARKER_RESOURCE_COUNTERS) return
+        bitmapCreations.addAndGet(created.toLong())
+        bitmapScaleOrCopy.addAndGet(scaleOrCopy.toLong())
+    }
+
+    fun recordBitmapRecycle(recycled: Int = 1) {
+        if (!DEBUG_MAP_MARKER_RESOURCE_COUNTERS) return
+        bitmapRecycles.addAndGet(recycled.toLong())
+    }
+
+    fun recordBitmapDescriptorFromBitmap() {
+        if (!DEBUG_MAP_MARKER_RESOURCE_COUNTERS) return
+        bitmapDescriptorsFromBitmap.incrementAndGet()
+        maybeLog("iconDescriptor event=fromBitmap")
+    }
+
+    fun recordBitmapDescriptorCacheHit(cacheSize: Int) {
+        if (!DEBUG_MAP_MARKER_RESOURCE_COUNTERS) return
+        bitmapDescriptorCacheHits.incrementAndGet()
+        maybeLog("iconDescriptor event=cacheHit cacheSize=$cacheSize")
+    }
+
+    fun recordBitmapDescriptorCacheMiss(cacheSize: Int) {
+        if (!DEBUG_MAP_MARKER_RESOURCE_COUNTERS) return
+        bitmapDescriptorCacheMisses.incrementAndGet()
+        maybeLog("iconDescriptor event=cacheMiss cacheSize=$cacheSize")
+    }
+
+    fun recordDbQuery(cellCount: Int, returnedStopCount: Int, usedBounds: Boolean) {
+        if (!DEBUG_MAP_MARKER_RESOURCE_COUNTERS) return
+        val count = dbQueries.incrementAndGet()
+        maybeLog(
+            "dbQuery event=queryStops query=$count cells=$cellCount stops=$returnedStopCount " +
+                "path=Room bounds=$usedBounds"
+        )
+    }
+
+    fun recordLocationFetch(cellCount: Int, inFlightCount: Int) {
+        if (!DEBUG_MAP_MARKER_RESOURCE_COUNTERS) return
+        val count = locationFetches.incrementAndGet()
+        maybeLog("network event=locationsFetch fetch=$count cells=$cellCount inFlight=$inFlightCount")
+    }
+
+    private fun maybeLog(message: String) {
+        val fdCount = fdCount()
+        val thresholdMessage = thresholdMessage(fdCount)
+        val now = System.currentTimeMillis()
+        val last = lastLogAtMs.get()
+        val shouldLog = thresholdMessage != null || now - last >= MIN_LOG_INTERVAL_MS
+        if (!shouldLog || !lastLogAtMs.compareAndSet(last, now)) return
+
+        Timber.tag(TAG).d(
+            "%s fd=%d%s camera=%d idle=%d emissions=%d batches=%d addedTotal=%d removedTotal=%d " +
+                "hiddenTotal=%d shownTotal=%d iconFetch=%d bitmapCreated=%d bitmapScaleCopy=%d " +
+                "bitmapRecycled=%d descriptorFromBitmap=%d descriptorCacheHits=%d descriptorCacheMisses=%d " +
+                "dbQueries=%d locationFetches=%d threads=%d javaHeapMb=%d nativeHeapMb=%d",
+            message,
+            fdCount,
+            thresholdMessage.orEmpty(),
+            cameraEvents.get(),
+            cameraIdleEvents.get(),
+            markerEmissions.get(),
+            markerRenderBatches.get(),
+            markersAdded.get(),
+            markersRemoved.get(),
+            markersHidden.get(),
+            markersShown.get(),
+            iconFetchCalls.get(),
+            bitmapCreations.get(),
+            bitmapScaleOrCopy.get(),
+            bitmapRecycles.get(),
+            bitmapDescriptorsFromBitmap.get(),
+            bitmapDescriptorCacheHits.get(),
+            bitmapDescriptorCacheMisses.get(),
+            dbQueries.get(),
+            locationFetches.get(),
+            threadCount(),
+            javaHeapMb(),
+            nativeHeapMb()
+        )
+    }
+
+    private fun fdCount(): Int = File("/proc/self/fd").list()?.size ?: -1
+
+    private fun threadCount(): Int = Thread.getAllStackTraces().size
+
+    private fun javaHeapMb(): Long {
+        val runtime = Runtime.getRuntime()
+        return (runtime.totalMemory() - runtime.freeMemory()) / BYTES_PER_MB
+    }
+
+    private fun nativeHeapMb(): Long = Debug.getNativeHeapAllocatedSize() / BYTES_PER_MB
+
+    private fun thresholdMessage(fdCount: Int): String? {
+        if (fdCount < 0) return null
+        while (true) {
+            val index = nextFdThresholdIndex.get()
+            if (index >= fdThresholds.size || fdCount < fdThresholds[index]) return null
+            if (nextFdThresholdIndex.compareAndSet(index, index + 1)) {
+                return " fdThreshold=${fdThresholds[index]}"
+            }
+        }
+    }
+
+    data class MarkerSnapshot(
+        val visible: Int,
+        val hidden: Int,
+        val total: Int,
+        val poiMarkers: Int,
+        val byIdentifier: Int,
+        val positions: Int,
+        val regional: Int
+    ) {
+        fun format(): String =
+            "visible=$visible hidden=$hidden total=$total poiMarkers=$poiMarkers " +
+                "byIdentifier=$byIdentifier positions=$positions regional=$regional"
+    }
+
+    fun snapshot(
+        collections: List<MarkerManager.Collection?>,
+        poiMarkers: MarkerManager.Collection?,
+        byIdentifierSize: Int,
+        positionsSize: Int,
+        regionalCount: Int
+    ): MarkerSnapshot {
+        if (!DEBUG_MAP_MARKER_RESOURCE_COUNTERS) {
+            return MarkerSnapshot(0, 0, 0, 0, 0, 0, 0)
+        }
+
+        var visible = 0
+        var hidden = 0
+        for (collection in collections) {
+            collection?.markers?.forEach { marker ->
+                if (marker.isVisible) visible++ else hidden++
+            }
+        }
+        val total = visible + hidden
+        return MarkerSnapshot(
+            visible = visible,
+            hidden = hidden,
+            total = total,
+            poiMarkers = poiMarkers?.markers?.size ?: 0,
+            byIdentifier = byIdentifierSize,
+            positions = positionsSize,
+            regional = regionalCount
+        )
+    }
+
+    private const val BYTES_PER_MB = 1024L * 1024L
+}

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/TripLine.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/TripLine.kt
@@ -72,31 +72,8 @@ open class GetTripLine @Inject internal constructor(
     private fun createPolylineListForTravelledLines(results: List<List<LineSegment>>?): List<SegmentsPolyLineOptions> {
         val polylineOptionsList = mutableListOf<PolylineOptions>()
         if (!results.isNullOrEmpty()) {
-            val lines = LinkedList<LatLng>()
             for (list in results) {
-
-                list.forEach {
-                    lines.clear()
-                    lines.add(LatLng(it.start.latitude, it.start.longitude))
-                    lines.add(LatLng(it.end.latitude, it.end.longitude))
-
-                    //Background only for non-black color lines to standout in map
-                    if (it.color != Color.BLACK) {
-                        polylineOptionsList.add(
-                            PolylineOptions()
-                                .addAll(lines)
-                                .color(Color.BLACK)
-                                .width(20f)
-                        )
-                    }
-
-                    polylineOptionsList.add(
-                        PolylineOptions()
-                            .addAll(lines)
-                            .color(it.color)
-                            .width((if (it.color != Color.BLACK) 14 else 15).toFloat())
-                    )
-                }
+                polylineOptionsList.addAll(list.toPolylineOptions())
             }
         }
         return listOf(
@@ -110,32 +87,16 @@ open class GetTripLine @Inject internal constructor(
     ): List<SegmentsPolyLineOptions> {
         val polylineOptionsList = mutableListOf<PolylineOptions>()
         if (!results.isNullOrEmpty()) {
-            val lines = LinkedList<LatLng>()
-            results.forEachIndexed { index, list ->
-                list.forEach {
-                    val color: Int
-                    val zIndex: Float
-                    if(config.activeTripUuid != null &&
-                        config.activeTripUuid == it.tripUuid) {
-                        color = config.activeColor
-                        zIndex = 5.0f
-                    } else {
-                        color = config.inActiveColor
-                        zIndex = 2.0f
+            results.forEach { list ->
+                polylineOptionsList.addAll(
+                    list.toPolylineOptions { lineSegment ->
+                        if (config.activeTripUuid != null && config.activeTripUuid == lineSegment.tripUuid) {
+                            PolylineStyle(config.activeColor, 5.0f)
+                        } else {
+                            PolylineStyle(config.inActiveColor, 2.0f)
+                        }
                     }
-
-                    lines.clear()
-                    lines.add(LatLng(it.start.latitude, it.start.longitude))
-                    lines.add(LatLng(it.end.latitude, it.end.longitude))
-
-                    polylineOptionsList.add(
-                        PolylineOptions()
-                            .addAll(lines)
-                            .color(color)
-                            .width((if (it.color != Color.BLACK) 14 else 15).toFloat())
-                            .zIndex(zIndex)
-                    )
-                }
+                )
             }
         }
         return listOf(
@@ -143,5 +104,59 @@ open class GetTripLine @Inject internal constructor(
                 polylineOptionsList, true
             )
         )
+    }
+
+    private data class PolylineStyle(
+        val color: Int,
+        val zIndex: Float? = null
+    )
+
+    private fun List<LineSegment>.toPolylineOptions(
+        styleProvider: (LineSegment) -> PolylineStyle = { PolylineStyle(it.color) }
+    ): List<PolylineOptions> {
+        val polylineOptionsList = mutableListOf<PolylineOptions>()
+        var currentStyle: PolylineStyle? = null
+        var currentPoints = LinkedList<LatLng>()
+
+        fun flushCurrentLine() {
+            val style = currentStyle ?: return
+            if (currentPoints.size < 2) return
+
+            if (style.color != Color.BLACK) {
+                polylineOptionsList.add(
+                    PolylineOptions()
+                        .addAll(currentPoints)
+                        .color(Color.BLACK)
+                        .width(20f)
+                        .apply { style.zIndex?.let(::zIndex) }
+                )
+            }
+
+            polylineOptionsList.add(
+                PolylineOptions()
+                    .addAll(currentPoints)
+                    .color(style.color)
+                    .width((if (style.color != Color.BLACK) 14 else 15).toFloat())
+                    .apply { style.zIndex?.let(::zIndex) }
+            )
+        }
+
+        forEach { lineSegment ->
+            val style = styleProvider(lineSegment)
+            val start = LatLng(lineSegment.start.latitude, lineSegment.start.longitude)
+            val end = LatLng(lineSegment.end.latitude, lineSegment.end.longitude)
+            val continuesCurrentLine = currentPoints.lastOrNull() == start
+
+            if (currentStyle != style || !continuesCurrentLine) {
+                flushCurrentLine()
+                currentStyle = style
+                currentPoints = LinkedList()
+                currentPoints.add(start)
+            }
+            currentPoints.add(end)
+        }
+
+        flushCurrentLine()
+        return polylineOptionsList
     }
 }

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/home/TripKitMapFragment.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/home/TripKitMapFragment.kt
@@ -60,6 +60,7 @@ import com.skedgo.tripkit.ui.map.MapCameraController
 import com.skedgo.tripkit.ui.map.MapMarkerUtils
 import com.skedgo.tripkit.ui.map.StopMarkerIconFetcher
 import com.skedgo.tripkit.ui.map.StopPOILocation
+import com.skedgo.tripkit.ui.map.TripGoMapMarkerDiag
 import com.skedgo.tripkit.ui.map.TripLocationMarkerCreator
 import com.skedgo.tripkit.ui.map.adapter.CityInfoWindowAdapter
 import com.skedgo.tripkit.ui.map.adapter.NoActionWindowAdapter
@@ -442,10 +443,13 @@ class TripKitMapFragment : LocationEnhancedMapFragment(), OnInfoWindowClickListe
                     return@subscribe
                 }
 
+                var removedCount = 0
+                var addedCount = 0
+
                 for (removedId in removedMarkerIds) {
                     val marker = poiMarkersByIdentifier.remove(removedId) ?: continue
-                    removeMarkerPosition(marker.position)
-                    marker.remove()
+                    removePoiMarker(marker)
+                    removedCount++
                 }
 
                 for ((markerOptions, poiLocation) in newMarkers) {
@@ -453,10 +457,18 @@ class TripKitMapFragment : LocationEnhancedMapFragment(), OnInfoWindowClickListe
                         return@subscribe
                     }
                     val identifier = poiLocation.identifier
-                    poiMarkersByIdentifier[identifier]?.let { existing ->
-                        removeMarkerPosition(existing.position)
-                        existing.remove()
+                    val existing = poiMarkersByIdentifier[identifier]
+                    if (existing != null && existing.position == markerOptions.position) {
+                        existing.tag = poiLocation
+                        if (!isMarkerPositionExists(existing.position)) {
+                            addMarkerPosition(existing.position)
+                        }
+                        continue
+                    }
+                    existing?.let {
                         poiMarkersByIdentifier.remove(identifier)
+                        removePoiMarker(it)
+                        removedCount++
                     }
                     if (isMarkerPositionExists(markerOptions.position)) {
                         continue
@@ -465,6 +477,16 @@ class TripKitMapFragment : LocationEnhancedMapFragment(), OnInfoWindowClickListe
                     marker.tag = poiLocation
                     addMarkerPosition(markerOptions.position)
                     poiMarkersByIdentifier[identifier] = marker
+                    addedCount++
+                }
+                if (TripGoMapMarkerDiag.isEnabled()) {
+                    TripGoMapMarkerDiag.recordMarkerBatch(
+                        newMarkerOptions = newMarkers.size,
+                        removedIds = removedMarkerIds.size,
+                        added = addedCount,
+                        removed = removedCount,
+                        snapshot = markerDiagSnapshot()
+                    )
                 }
             }, {
                 errorLogger.logError(it)
@@ -647,6 +669,7 @@ class TripKitMapFragment : LocationEnhancedMapFragment(), OnInfoWindowClickListe
     }
 
     override fun onCameraChange(position: CameraPosition) {
+        TripGoMapMarkerDiag.recordCameraEvent()
         if (!isAdded) { // To investigate further this scenario.
             return
         }
@@ -1155,6 +1178,9 @@ class TripKitMapFragment : LocationEnhancedMapFragment(), OnInfoWindowClickListe
                 onZoomLevelChangedListener?.onZoomLevelChanged(lastZoomLevel)
             }
         }
+        if (TripGoMapMarkerDiag.isEnabled()) {
+            TripGoMapMarkerDiag.recordCameraIdle(markerDiagSnapshot())
+        }
     }
 
     fun setShowMarkers(
@@ -1401,6 +1427,14 @@ class TripKitMapFragment : LocationEnhancedMapFragment(), OnInfoWindowClickListe
                     markerCountAfter
                 )
             }
+            if (TripGoMapMarkerDiag.isEnabled()) {
+                TripGoMapMarkerDiag.recordMarkerCleanup(
+                    event = "clearNonRegionalMarkers",
+                    before = markerCountBefore,
+                    after = poiMarkers?.markers?.size ?: 0,
+                    snapshot = markerDiagSnapshot()
+                )
+            }
         }
     }
 
@@ -1422,21 +1456,37 @@ class TripKitMapFragment : LocationEnhancedMapFragment(), OnInfoWindowClickListe
             poiMarkers?.hideAll()
             arrivalMarkers?.hideAll()
             departureMarkers?.hideAll()
+            if (TripGoMapMarkerDiag.isEnabled()) {
+                TripGoMapMarkerDiag.recordMarkerVisibility(
+                    hidden = 0,
+                    shown = 0,
+                    snapshot = markerDiagSnapshot()
+                )
+            }
             return
         }
 
         lastViewportBounds = currentBounds
 
         // Hide/show markers in each collection based on viewport
-        hideMarkersInCollection(poiMarkers, currentBounds)
-        hideMarkersInCollection(cityMarkers, currentBounds)
-        hideMarkersInCollection(tripLocationMarkers, currentBounds)
-        hideMarkersInCollection(departureMarkers, currentBounds)
-        hideMarkersInCollection(arrivalMarkers, currentBounds)
-        hideMarkersInCollection(currentLocationMarkers, currentBounds)
+        val countVisibilityChanges = TripGoMapMarkerDiag.isEnabled()
+        var visibilityChanges = 0L
+        visibilityChanges += hideMarkersInCollection(poiMarkers, currentBounds, countVisibilityChanges)
+        visibilityChanges += hideMarkersInCollection(cityMarkers, currentBounds, countVisibilityChanges)
+        visibilityChanges += hideMarkersInCollection(tripLocationMarkers, currentBounds, countVisibilityChanges)
+        visibilityChanges += hideMarkersInCollection(departureMarkers, currentBounds, countVisibilityChanges)
+        visibilityChanges += hideMarkersInCollection(arrivalMarkers, currentBounds, countVisibilityChanges)
+        visibilityChanges += hideMarkersInCollection(currentLocationMarkers, currentBounds, countVisibilityChanges)
 
         // Handle individual markers that aren't in collections
         hideIndividualMarkers(currentBounds)
+        if (countVisibilityChanges) {
+            TripGoMapMarkerDiag.recordMarkerVisibility(
+                hidden = hiddenCount(visibilityChanges),
+                shown = shownCount(visibilityChanges),
+                snapshot = markerDiagSnapshot()
+            )
+        }
     }
 
     /**
@@ -1446,12 +1496,15 @@ class TripKitMapFragment : LocationEnhancedMapFragment(), OnInfoWindowClickListe
      */
     private fun hideMarkersInCollection(
         collection: MarkerManager.Collection?,
-        viewportBounds: LatLngBounds
-    ) {
-        collection ?: return
+        viewportBounds: LatLngBounds,
+        countVisibilityChanges: Boolean = false
+    ): Long {
+        collection ?: return 0L
 
         val zoom = map?.cameraPosition?.zoom ?: 0f
         val isPOIZoom = zoom > 12.1f && zoom < 14.5f
+        var hidden = 0
+        var shown = 0
 
         // Iterate once and set visibility based on the rule for this zoom level
         for (marker in collection.markers) {
@@ -1467,6 +1520,9 @@ class TripKitMapFragment : LocationEnhancedMapFragment(), OnInfoWindowClickListe
                 }
 
             if (marker.isVisible != shouldBeVisible) {
+                if (countVisibilityChanges) {
+                    if (shouldBeVisible) shown++ else hidden++
+                }
                 marker.isVisible = shouldBeVisible
             }
             if (
@@ -1479,6 +1535,7 @@ class TripKitMapFragment : LocationEnhancedMapFragment(), OnInfoWindowClickListe
                 marker.showInfoWindow()
             }
         }
+        return visibilityChangeCounts(hidden, shown)
     }
 
 
@@ -1521,6 +1578,37 @@ class TripKitMapFragment : LocationEnhancedMapFragment(), OnInfoWindowClickListe
             marker.isVisible = bounds.contains(marker.position)
         }
     }
+
+    private fun markerDiagSnapshot(): TripGoMapMarkerDiag.MarkerSnapshot =
+        TripGoMapMarkerDiag.snapshot(
+            collections = listOf(
+                poiMarkers,
+                cityMarkers,
+                tripLocationMarkers,
+                departureMarkers,
+                arrivalMarkers,
+                currentLocationMarkers
+            ),
+            poiMarkers = poiMarkers,
+            byIdentifierSize = poiMarkersByIdentifier.size,
+            positionsSize = existingMarkerPositions.size,
+            regionalCount = MapData.getRegionalStops().size
+        )
+
+    private fun removePoiMarker(marker: Marker) {
+        markerHideCallbacks.remove(marker)
+        removeMarkerPosition(marker.position)
+        if (poiMarkers?.remove(marker) != true) {
+            marker.remove()
+        }
+    }
+
+    private fun visibilityChangeCounts(hidden: Int, shown: Int): Long =
+        (hidden.toLong() shl 32) or (shown.toLong() and 0xffffffffL)
+
+    private fun hiddenCount(counts: Long): Int = (counts shr 32).toInt()
+
+    private fun shownCount(counts: Long): Int = counts.toInt()
 
     /**
      * Check if two bounds are similar enough to avoid unnecessary updates

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/home/TripKitMapFragment.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/map/home/TripKitMapFragment.kt
@@ -728,7 +728,7 @@ class TripKitMapFragment : LocationEnhancedMapFragment(), OnInfoWindowClickListe
         }
 
         if(position.zoom > ZoomLevel.ZOOM_VALUE_TO_SHOW_CITIES) {
-            Timber.i("========== ${position.zoom} ============")
+//            Timber.i("========== ${position.zoom} ============")
             hideMarkersOutsideViewport()
         }
     }

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/servicedetail/ServiceDetailViewModel.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/servicedetail/ServiceDetailViewModel.kt
@@ -211,11 +211,16 @@ class ServiceDetailViewModel @Inject constructor(
         regionService.getRegionByLocationAsync(segment.from)
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe({
+                val serviceName = if (segment.serviceName != segment.serviceDirection) {
+                    segment.serviceDirection
+                } else {
+                    segment.serviceName
+                }
                 setup(
                     region = it.name.orEmpty(),
                     regionUrls = it.getURLs(),
                     serviceId = segment.serviceTripId.orEmpty(),
-                    serviceName = segment.serviceName,
+                    serviceName = serviceName,
                     serviceNumber = segment.serviceNumber,
                     serviceColor = segment.serviceColor,
                     operator = segment.serviceOperator,
@@ -242,14 +247,18 @@ class ServiceDetailViewModel @Inject constructor(
         regionService.getRegionByLocationAsync(_stop)
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe({
+                val serviceName = if (_entry.serviceName.isNullOrEmpty()) {
+                    getServiceTertiaryText.execute(_entry)
+                } else if (_entry.serviceName != _entry.serviceDirection) {
+                    _entry.serviceDirection
+                } else {
+                    _entry.serviceName
+                }
                 setup(
                     region = it.name.orEmpty(),
                     regionUrls = it.getURLs(),
                     serviceId = _entry.serviceTripId.orEmpty(),
-                    serviceName = if (!_entry.serviceName.isNullOrEmpty())
-                        _entry.serviceName.orEmpty()
-                    else
-                        getServiceTertiaryText.execute(_entry),
+                    serviceName = serviceName,
                     serviceNumber = _entry.serviceNumber,
                     serviceColor = _entry.serviceColor,
                     operator = _entry.operator,

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/timetables/TimetableViewModel.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/timetables/TimetableViewModel.kt
@@ -113,6 +113,7 @@ internal fun createVisibleServiceViewModels(
                     .subscribeWithErrorHandling { entry ->
                         timetableEntryChosen.accept(entry)
                     }
+                    .autoClear()
             }
         }
 }
@@ -166,11 +167,13 @@ class TimetableViewModel @Inject constructor(
         override fun areContentsTheSame(
             oldItem: ServiceViewModel,
             newItem: ServiceViewModel
-        ): Boolean =
-            oldItem.serviceNumber.value == newItem.serviceNumber.value
+        ): Boolean {
+            if (oldItem !== newItem) return false
+            return oldItem.serviceNumber.value == newItem.serviceNumber.value
                 && oldItem.secondaryText.value == newItem.secondaryText.value
                 && oldItem.tertiaryText.value == newItem.tertiaryText.value
                 && oldItem.countDownTimeText.value == newItem.countDownTimeText.value
+        }
 
 
     }
@@ -244,7 +247,9 @@ class TimetableViewModel @Inject constructor(
                                 request.isSelectedTime
                             )
                         )
-                        timeInSecs.set(it.first.last().startTimeInSecs + 1)
+                        it.first.lastOrNull()?.let { lastService ->
+                            timeInSecs.set(lastService.startTimeInSecs + 1)
+                        }
                     }, {
                         it.printStackTrace()
                         emitter.onError(it)
@@ -478,6 +483,9 @@ class TimetableViewModel @Inject constructor(
 
     private suspend fun applyServicesUpdateSafely(nextItems: List<ServiceViewModel>) {
         servicesUpdateMutex.withLock {
+            val itemsToClear = services.filter { oldItem ->
+                nextItems.none { newItem -> newItem === oldItem }
+            }
             val diff = withContext(Dispatchers.Default) { services.calculateDiff(nextItems) }
             withContext(Dispatchers.Main.immediate) {
                 runCatching {
@@ -486,6 +494,8 @@ class TimetableViewModel @Inject constructor(
                     Timber.w(firstError, "Primary timetable diff apply failed, retrying with fresh diff")
                     // Retry with a fresh diff against the latest adapter state.
                     services.update(nextItems)
+                }.onSuccess {
+                    itemsToClear.forEach { it.onCleared() }
                 }.onFailure { finalError ->
                     Timber.e(finalError, "Failed to apply timetable services update safely")
                 }

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/timetables/TimetableViewModel.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/timetables/TimetableViewModel.kt
@@ -54,6 +54,7 @@ import me.tatarka.bindingcollectionadapter2.collections.DiffObservableList
 import org.joda.time.DateTimeZone
 import timber.log.Timber
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Provider
 import kotlin.math.max
@@ -63,6 +64,58 @@ data class ShowTimetableEntry(
     val trip: Trip,
     val tripSegment: TripSegment
 )
+
+private data class TimetableRequest(
+    val sinceTimeInSecs: Long,
+    val region: Region,
+    val stop: ScheduledStop,
+    val isSelectedTime: Boolean
+)
+
+private data class TimetableServicesResult(
+    val services: List<TimetableEntry>,
+    val parentStop: Optional<ScheduledStop>,
+    val isSelectedTime: Boolean
+)
+
+internal fun TimetableEntry.departureCountDownTimeInMins(nowInMillis: Long): Long {
+    val secsToDepart = TimeUnit.SECONDS.toMillis(realTimeDeparture(this, realtimeVehicle)) - nowInMillis
+    return TimeUnit.MILLISECONDS.toMinutes(secsToDepart)
+}
+
+internal fun TimetableEntry.shouldHideServiceViewModelInCurrentTimeMode(
+    isSelectedTime: Boolean,
+    nowInMillis: Long
+): Boolean {
+    if (isSelectedTime) return false
+
+    val hasDepartedCountdown = !isFrequencyBased && departureCountDownTimeInMins(nowInMillis) < 0
+    return hasDepartedCountdown || isCancelled
+}
+
+internal fun createVisibleServiceViewModels(
+    services: List<TimetableEntry>,
+    currentTripId: String,
+    timeZone: DateTimeZone,
+    isSelectedTime: Boolean,
+    nowInMillis: Long,
+    serviceViewModelProvider: Provider<ServiceViewModel>,
+    timetableEntryChosen: PublishRelay<TimetableEntry>
+): List<ServiceViewModel> {
+    return services
+        .filterNot {
+            it.shouldHideServiceViewModelInCurrentTimeMode(isSelectedTime, nowInMillis)
+        }
+        .map {
+            serviceViewModelProvider.get().apply {
+                this.setService(currentTripId, it, timeZone)
+                this.onItemClick.observable.observeOn(AndroidSchedulers.mainThread())
+                    .subscribeWithErrorHandling { entry ->
+                        timetableEntryChosen.accept(entry)
+                    }
+            }
+        }
+}
 
 class TimetableViewModel @Inject constructor(
     private val realTimeChoreographer: RealTimeChoreographer,
@@ -149,28 +202,34 @@ class TimetableViewModel @Inject constructor(
     }
     private var _currentServiceTripId: String? = null
 
-    val minStartTime = onDateChanged.mergeWith(downloadTimetable).map { it }
+    private val minStartTimeWithMode = Observable.merge(
+        downloadTimetable.map { it to false },
+        onDateChanged.map { it to true }
+    )
+
+    val minStartTime = minStartTimeWithMode.map { it.first }
 
     private val servicesAndParentStop = Observables
-        .combineLatest(minStartTime, currentServiceTripId, regionObservable, stop)
-        { sinceTimeInSecs, currentServiceTripId, region, stop ->
+        .combineLatest(minStartTimeWithMode, currentServiceTripId, regionObservable, stop)
+        { minStartTimeWithMode, currentServiceTripId, region, stop ->
+            val sinceTimeInSecs = minStartTimeWithMode.first
             val time = if (currentServiceTripId.isNullOrEmpty()) {
                 sinceTimeInSecs / 1000
             } else {
                 sinceTimeInSecs
             }
-            Triple(time, region, stop)
+            TimetableRequest(time, region, stop, minStartTimeWithMode.second)
         }
-        .switchMap { (sinceTimeInSecs, region, stop) ->
-            Flowable.create<Pair<List<TimetableEntry>, Optional<ScheduledStop>>>({ emitter ->
-                val timeInSecs = AtomicLong(sinceTimeInSecs)
+        .switchMap { request ->
+            Flowable.create<TimetableServicesResult>({ emitter ->
+                val timeInSecs = AtomicLong(request.sinceTimeInSecs)
                 val subscription = loadMore
                     .startWith(Unit)
                     .switchMap {
                         fetchAndLoadTimetable.execute(
-                            stop.embarkationStopCode,
-                            stop.disembarkationStopCode,
-                            region,
+                            request.stop.embarkationStopCode,
+                            request.stop.disembarkationStopCode,
+                            request.region,
                             timeInSecs.get()
                         )
                             .toObservable()
@@ -178,7 +237,13 @@ class TimetableViewModel @Inject constructor(
                             .isExecuting { showLoading.postValue(it) }
                     }
                     .subscribe({
-                        emitter.onNext(it)
+                        emitter.onNext(
+                            TimetableServicesResult(
+                                it.first,
+                                it.second,
+                                request.isSelectedTime
+                            )
+                        )
                         timeInSecs.set(it.first.last().startTimeInSecs + 1)
                     }, {
                         it.printStackTrace()
@@ -190,7 +255,13 @@ class TimetableViewModel @Inject constructor(
                     throwable.printStackTrace()
                     Timber.e("An error occurred", throwable)
                 }
-                .scan { a, b -> (a.first + b.first) to b.second }
+                .scan { a, b ->
+                    TimetableServicesResult(
+                        a.services + b.services,
+                        b.parentStop,
+                        b.isSelectedTime
+                    )
+                }
         }
         .doOnError { throwable: Throwable ->
             throwable.printStackTrace()
@@ -200,7 +271,7 @@ class TimetableViewModel @Inject constructor(
         .refCount()
 
     private val parentStop = servicesAndParentStop
-        .map { it.second }
+        .map { it.parentStop }
         .ignoreNetworkErrors()
         .withLatestFrom(
             stop,
@@ -215,13 +286,14 @@ class TimetableViewModel @Inject constructor(
     private val realtimeRelay = PublishRelay.create<Unit>()
 
     private val servicesVMs = Observables.combineLatest(
-        servicesAndParentStop.map { it.first },
+        servicesAndParentStop,
         regionObservable,
         currentServiceTripId
-    ) { services: List<TimetableEntry>, region: Region, currentTripId: String ->
-        Triple(services, region, currentTripId)
+    ) { servicesResult: TimetableServicesResult, region: Region, currentTripId: String ->
+        Triple(servicesResult, region, currentTripId)
     }.flatMap {
-        val services = it.first
+        val servicesResult = it.first
+        val services = servicesResult.services
         val region = it.second
         _currentServiceTripId = it.third
         realTimeChoreographer.getRealTimeResultsFromCleanElements(region, elements = services)
@@ -236,22 +308,22 @@ class TimetableViewModel @Inject constructor(
                 }
                 services
             }
-            .map { it to region }
-            .startWith(services to region)
+            .map { Triple(it, region, servicesResult.isSelectedTime) }
+            .startWith(Triple(services, region, servicesResult.isSelectedTime))
     }.map {
         val services = it.first
         val region = it.second
         val timeZone = DateTimeZone.forID(region.timezone)
 
-        services.map {
-            serviceViewModelProvider.get().apply {
-                this.setService(_currentServiceTripId ?: "", it, timeZone)
-                this.onItemClick.observable.observeOn(AndroidSchedulers.mainThread())
-                    .subscribeWithErrorHandling { entry ->
-                        timetableEntryChosen.accept(entry)
-                    }
-            }
-        }
+        createVisibleServiceViewModels(
+            services,
+            _currentServiceTripId ?: "",
+            timeZone,
+            it.third,
+            getNow.execute().millis,
+            serviceViewModelProvider,
+            timetableEntryChosen
+        )
     }.map {
         it.sortedBy { it.getRealTimeDeparture() }
     }.let {

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripResultMapContributor.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripResultMapContributor.kt
@@ -63,6 +63,11 @@ import java.util.Collections
 import javax.inject.Inject
 
 class TripResultMapContributor : TripKitMapContributor {
+    private companion object {
+        const val MAX_TRAVELLED_POLYLINES_TO_HIGHLIGHT = 300
+        const val MIN_FREE_HEAP_BYTES_FOR_POLYLINE_HIGHLIGHT = 8 * 1024 * 1024L
+    }
+
     private var travelledStopMarkers: MarkerManager.Collection? = null
     private var vehicleMarkers: MarkerManager.Collection? = null
     private var segmentMarkers: MarkerManager.Collection? = null
@@ -456,16 +461,22 @@ class TripResultMapContributor : TripKitMapContributor {
     }
 
     fun focusTripLine(segment: TripSegment) {
-        val segmentPolyLines = segment.getPolyLines()
+        val segmentPolyLines = if (shouldHighlightTravelledPolyLines()) {
+            segment.getPolyLines()
+        } else {
+            emptyList()
+        }
 
-        updateTravelledPolyLinesHighlight(segmentPolyLines)
+        if (segmentPolyLines.isNotEmpty()) {
+            updateTravelledPolyLinesHighlight(segmentPolyLines)
+        }
 
         val bounds = segmentPolyLines
             .flatMap { it.points }
             .takeIf { it.isNotEmpty() }
             ?.let { points ->
                 LatLngBounds.builder().apply { points.forEach(::include) }.build()
-            }
+            } ?: segment.getFallbackBounds()
 
         if (bounds != null) {
             val cameraUpdate = CameraUpdateFactory.newLatLngBounds(bounds, 50)
@@ -479,14 +490,38 @@ class TripResultMapContributor : TripKitMapContributor {
         }
     }
 
+    private fun shouldHighlightTravelledPolyLines(): Boolean {
+        val runtime = Runtime.getRuntime()
+        val freeHeapBytes = runtime.maxMemory() - (runtime.totalMemory() - runtime.freeMemory())
+        return tripLinesTravelled.size <= MAX_TRAVELLED_POLYLINES_TO_HIGHLIGHT &&
+            freeHeapBytes >= MIN_FREE_HEAP_BYTES_FOR_POLYLINE_HIGHLIGHT
+    }
+
     private fun updateTravelledPolyLinesHighlight(segmentPolyLines: List<Polyline>) {
         tripLinesTravelled.forEach { polyLine ->
-            if (segmentPolyLines.any { it == polyLine }) {
-                polyLine.color = polyLine.color.removeAlpha()
+            val targetColor = if (segmentPolyLines.any { it == polyLine }) {
+                polyLine.color.removeAlpha()
             } else {
-                polyLine.color = polyLine.color.adjustAlpha(0.25f)
+                polyLine.color.adjustAlpha(0.25f)
+            }
+            if (polyLine.color != targetColor) {
+                try {
+                    polyLine.color = targetColor
+                } catch (error: OutOfMemoryError) {
+                    Timber.e(error, "Skipping trip line highlight due to low memory.")
+                    return
+                }
             }
         }
+    }
+
+    private fun TripSegment.getFallbackBounds(): LatLngBounds? {
+        val points = listOfNotNull(from, singleLocation, to).map { it.toLatLng() }
+        return points
+            .takeIf { it.isNotEmpty() }
+            ?.let {
+                LatLngBounds.builder().apply { it.forEach(::include) }.build()
+            }
     }
 
     private fun TripSegment.getPolyLines() =

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripResultMapContributor.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripResultMapContributor.kt
@@ -117,6 +117,9 @@ class TripResultMapContributor : TripKitMapContributor {
     protected val autoDisposable: CompositeDisposable by lazy {
         CompositeDisposable()
     }
+    private val segmentMarkerIconDisposables: CompositeDisposable by lazy {
+        CompositeDisposable()
+    }
 
     private var context: Context? = null
     private lateinit var map: GoogleMap
@@ -248,7 +251,6 @@ class TripResultMapContributor : TripKitMapContributor {
             map.isIndoorEnabled = false
             map.uiSettings.isRotateGesturesEnabled = true
 
-            drawSegmentMarkers(context)
         }
     }
 
@@ -335,6 +337,7 @@ class TripResultMapContributor : TripKitMapContributor {
                     processMapTiles(it)
                 }, { Timber.e(it) })
         )
+        drawSegmentMarkers(context)
     }
 
     fun processMapTiles(tripKitMapTiles: List<String>) {
@@ -369,6 +372,7 @@ class TripResultMapContributor : TripKitMapContributor {
         observersSetUp = false
         
         autoDisposable.clear()
+        segmentMarkerIconDisposables.clear()
         travelledStopMarkers?.clear()
         vehicleMarkers?.clear()
         segmentMarkers?.clear()
@@ -573,6 +577,7 @@ class TripResultMapContributor : TripKitMapContributor {
         context: Context,
         segmentMarkerViewModels: List<Pair<TripSegment, MarkerOptions>>
     ) {
+        segmentMarkerIconDisposables.clear()
         segmentMarkers?.clear()
         for (viewModel in segmentMarkerViewModels) {
             showSegmentMarker(context, viewModel)
@@ -588,7 +593,7 @@ class TripResultMapContributor : TripKitMapContributor {
         marker?.tag = segment
         val url = TransportModeUtils.getIconUrlForModeInfo(context.resources, segment.modeInfo)
         if (url != null) {
-            autoDisposable.add(picasso.fetchAsync(url)
+            segmentMarkerIconDisposables.add(picasso.fetchAsync(url)
                 .map { it: Bitmap? -> BitmapDrawable(context.resources, it) }
                 .map { it: BitmapDrawable? -> segmentMarkerIconMaker.make(segment, it) }
                 .compose(toTrySingle { error: Throwable? -> error is UnableToFetchBitmapError })

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripSegmentListFragment.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripSegmentListFragment.kt
@@ -107,6 +107,7 @@ class TripSegmentListFragment : BaseTripKitFragment(), View.OnClickListener {
     lateinit var binding: TripSegmentListFragmentBinding
     private var tripGroupId: String? = null
     private var tripId: Long? = null
+    private var preloadedTripGroup: TripGroup? = null
     var actionButtonHandlerFactory: ActionButtonHandlerFactory? = null
     private var tripResultMapContributor: TripResultMapContributor? = null
     private var updateStream: PublishSubject<Unit>? = null
@@ -136,13 +137,13 @@ class TripSegmentListFragment : BaseTripKitFragment(), View.OnClickListener {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        viewModel.tripGroupObservable
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribe { tripGroup ->
-                /* FIXME: Check if this could be removed */
-                tripGroup.displayTrip?.getBookingSegment()?.booking
-                    ?.externalActions?.forEach {}
-            }.addTo(autoDisposable)
+//        viewModel.tripGroupObservable
+//            .observeOn(AndroidSchedulers.mainThread())
+//            .subscribe { tripGroup ->
+//                /* FIXME: Check if this could be removed */
+//                tripGroup.displayTrip?.getBookingSegment()?.booking
+//                    ?.externalActions?.forEach {}
+//            }.addTo(autoDisposable)
     }
 
     override fun onCreateView(
@@ -169,8 +170,14 @@ class TripSegmentListFragment : BaseTripKitFragment(), View.OnClickListener {
         viewModel.showCloseButton.value = showCloseButton
         binding.closeButton.setOnClickListener(onCloseButtonListener)
 
-        tripGroupId?.let {
-            viewModel.loadTripGroup(it, tripId ?: -1L, savedInstanceState)
+        tripGroupId?.let { id ->
+            // Paint immediately from the already-parsed group when available (avoids the
+            // 2-3s blank from re-reading + deserializing a many-segment group), then keep the
+            // DB/realtime subscription so subsequent updates still flow in.
+            preloadedTripGroup?.let { group ->
+                viewModel.renderTripGroup(group, tripId ?: -1L, savedInstanceState)
+            }
+            viewModel.loadTripGroup(id, tripId ?: -1L, savedInstanceState)
         }
 
         // Reduce layout conflicts and detach issues: disable item animations on the main list
@@ -188,17 +195,6 @@ class TripSegmentListFragment : BaseTripKitFragment(), View.OnClickListener {
         
         // Ensure action button handler factory is available
         ensureActionButtonHandlerFactory()
-//        viewModel.tripGroupObservable
-//                .observeOn(mainThread())
-//                .take(1)
-//                .subscribe { tripGroup ->
-//                    buttonConfigurator?.let { configurator ->
-//                        binding.buttonLayout.forEach {
-//                            configurator.configureButton(context!!, it, tripGroup)
-//                        }
-//                    }
-//
-//                }.addTo(autoDisposable)
     }
 
     override fun onResume() {
@@ -508,6 +504,7 @@ class TripSegmentListFragment : BaseTripKitFragment(), View.OnClickListener {
     class Builder {
         private var tripGroupId: String? = null
         private var tripId: Long? = null
+        private var preloadedTripGroup: TripGroup? = null
         private var buttons: List<TripKitButton>? = null
         private var buttonConfigurator: TripKitButtonConfigurator? = null
         private var showCloseButton = false
@@ -526,6 +523,11 @@ class TripSegmentListFragment : BaseTripKitFragment(), View.OnClickListener {
             tripId?.let {
                 this.tripId = it
             }
+            return this
+        }
+
+        fun withTripGroup(tripGroup: TripGroup?): Builder {
+            this.preloadedTripGroup = tripGroup
             return this
         }
 
@@ -567,6 +569,7 @@ class TripSegmentListFragment : BaseTripKitFragment(), View.OnClickListener {
             fragment.arguments = args
             fragment.tripGroupId = tripGroupId
             fragment.tripId = tripId ?: -1
+            fragment.preloadedTripGroup = preloadedTripGroup
             fragment.actionButtonHandlerFactory = actionButtonHandlerFactory
             fragment.tripResultMapContributor = tripResultMapContributor
             fragment.updateStream = updateStream

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripSegmentsViewModel.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/TripSegmentsViewModel.kt
@@ -283,6 +283,25 @@ class TripSegmentsViewModel @Inject internal constructor(
     }
 
     /**
+     * Immediately renders an already-parsed [TripGroup] that the caller holds in memory
+     * (e.g. the pager's initial list), so the segment list can paint without waiting for a
+     * fresh DB read + full deserialization. [loadTripGroup] is still used afterwards to keep
+     * receiving DB/realtime updates for the same group.
+     */
+    fun renderTripGroup(
+        tripGroup: TripGroup,
+        tripId: Long,
+        savedInstanceState: Bundle?
+    ) {
+        if (tripId != -1L) {
+            tripGroup.displayTripId = tripId
+        }
+        setTitleAndSubtitle(tripGroup, tripId)
+        setTripGroup(tripGroup, tripId, savedInstanceState)
+        setupButtons(tripGroup)
+    }
+
+    /**
      * Creates or updates action buttons for the current display trip.
      *
      * During state restoration we may already have placeholder button view models from

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/v2/TripGroupsPagerAdapter.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/tripresult/v2/TripGroupsPagerAdapter.kt
@@ -59,6 +59,7 @@ class TripGroupsPagerAdapter(
         return TripSegmentListFragment.Builder()
             .withTripGroupId(tripGroup.uuid())
             .withTripId(tripId ?: tripGroup.displayTripId)
+            .withTripGroup(tripGroup)
             .withActionButtonHandlerFactory(actionButtonHandlerFactory)
             .withMapContributor(tripResultMapContributor)
             .showCloseButton(showCloseButton)

--- a/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/utils/TimeSpanUtils.kt
+++ b/TripKitAndroidUI/src/main/java/com/skedgo/tripkit/ui/utils/TimeSpanUtils.kt
@@ -28,6 +28,6 @@ object TimeSpanUtils {
                 timeUnit = StyleManager.FORMAT_TIME_SPAN_HOUR
             }
         }
-        return String.format(FORMAT_TIME_SPAN, sign * timeNumber, timeUnit)
+        return (sign * timeNumber).toString() + " " + timeUnit
     }
 }

--- a/TripKitAndroidUI/src/main/res/layout/bike_share_info_window.xml
+++ b/TripKitAndroidUI/src/main/res/layout/bike_share_info_window.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:background="@color/white"
     android:foreground="?selectableItemBackground"
     android:padding="8dp">
 

--- a/TripKitAndroidUI/src/main/res/layout/free_floating_vehicle_info_window.xml
+++ b/TripKitAndroidUI/src/main/res/layout/free_floating_vehicle_info_window.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:background="@color/white"
     android:padding="8dp"
     tools:ignore="UnusedAttribute">
 

--- a/TripKitAndroidUI/src/main/res/layout/service_detail_fragment.xml
+++ b/TripKitAndroidUI/src/main/res/layout/service_detail_fragment.xml
@@ -102,6 +102,12 @@
         <include
             android:id="@+id/content"
             layout="@layout/service_detail_fragment_content"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/iconLayout"
             bind:viewModel="@{viewModel}" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/TripKitAndroidUI/src/main/res/layout/service_detail_fragment_content.xml
+++ b/TripKitAndroidUI/src/main/res/layout/service_detail_fragment_content.xml
@@ -11,18 +11,26 @@
             type="com.skedgo.tripkit.ui.servicedetail.ServiceDetailViewModel" />
     </data>
 
-    <merge>
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
         <TextView
             android:id="@+id/details"
             style="@style/TextAppearance.MaterialComponents.Caption"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
             android:layout_marginTop="8dp"
             android:text="@{viewModel.tertiaryText}"
             android:textColor="@color/black1"
-            app:layout_constraintStart_toStartOf="@+id/iconLayout"
-            app:layout_constraintTop_toBottomOf="@+id/iconLayout"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
             tools:text="Fürth" />
 
         <View
@@ -225,13 +233,6 @@
             android:visibility="@{viewModel.isLoading()}"
             app:layout_constraintTop_toBottomOf="@id/secondDividingLine"/>
 
-        <!--
-            nestedScrollingEnabled="false" is required so that BottomSheetBehavior's
-            findScrollingChild() unambiguously picks the main stop-list RecyclerView below
-            as the nested scrolling child. Otherwise rvAlerts (appearing first in the view
-            tree) would be cached as nestedScrollingChildRef in older Material Library
-            versions, breaking both the list→sheet drag handoff and the header drag.
-        -->
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rvAlerts"
             android:layout_width="match_parent"
@@ -250,9 +251,9 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recyclerView"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
+            android:layout_height="wrap_content"
             android:focusableInTouchMode="true"
-            android:nestedScrollingEnabled="true"
+            android:nestedScrollingEnabled="false"
             android:requiresFadingEdge="vertical|horizontal"
             app:itemBinding="@{viewModel.itemBinding}"
             app:items="@{viewModel.items}"
@@ -263,5 +264,7 @@
             tools:visibility="visible"
             tools:listitem="@layout/service_detail_fragment_list_item"/>
 
-    </merge>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
 </layout>

--- a/TripKitAndroidUI/src/main/res/layout/service_detail_fragment_content.xml
+++ b/TripKitAndroidUI/src/main/res/layout/service_detail_fragment_content.xml
@@ -74,8 +74,7 @@
                     android:layout_height="@dimen/service_detail_icon_size"
                     android:layout_marginStart="@dimen/spacing_small"
                     android:src="@drawable/ic_bike"
-                    android:visibility="@{viewModel.showBicycleAccessible}"
-                    app:tint="@color/black2" />
+                    android:visibility="@{viewModel.showBicycleAccessible}" />
 
                 <ImageView
                     android:id="@+id/occupancyView"
@@ -136,8 +135,7 @@
                     <ImageView
                         android:layout_width="@dimen/service_detail_icon_size"
                         android:layout_height="@dimen/service_detail_icon_size"
-                        android:src="@drawable/ic_bike"
-                        app:tint="@color/black2" />
+                        android:src="@drawable/ic_bike" />
 
                     <TextView
                         android:id="@+id/tvBicycleLabel"

--- a/TripKitAndroidUI/src/test/java/com/skedgo/tripkit/ui/timetables/TimetableDepartedRealtimeFilterTest.kt
+++ b/TripKitAndroidUI/src/test/java/com/skedgo/tripkit/ui/timetables/TimetableDepartedRealtimeFilterTest.kt
@@ -1,0 +1,216 @@
+package com.skedgo.tripkit.ui.timetables
+
+import android.graphics.drawable.Drawable
+import androidx.lifecycle.MutableLiveData
+import com.jakewharton.rxrelay2.PublishRelay
+import com.skedgo.tripkit.common.model.realtimealert.RealtimeAlert
+import com.skedgo.tripkit.routing.ModeInfo
+import com.skedgo.tripkit.routing.RealTimeVehicle
+import com.skedgo.tripkit.ui.base.MockKTest
+import com.skedgo.tripkit.ui.model.TimetableEntry
+import com.skedgo.tripkit.ui.trip.details.viewmodel.OccupancyViewModel
+import com.skedgo.tripkit.ui.trip.details.viewmodel.ServiceAlertViewModel
+import com.skedgo.tripkit.ui.utils.TapAction
+import io.mockk.mockk
+import org.joda.time.DateTimeZone
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+import javax.inject.Provider
+
+class TimetableDepartedRealtimeFilterTest : MockKTest() {
+
+    @Before
+    fun setUp() {
+        initRx()
+    }
+
+    @After
+    fun tearDown() {
+        tearDownRx()
+    }
+
+    @Test
+    fun `current time mode does not create visible ServiceViewModel for negative countdown`() {
+        val service = timetableEntry(serviceTripId = "past", departureSecs = NOW_SECS - 60)
+
+        val visible = createVisibleServiceViewModels(listOf(service), isSelectedTime = false)
+
+        assertEquals(emptyList<String>(), visible.serviceTripIds())
+    }
+
+    @Test
+    fun `current time mode keeps visible ServiceViewModel for zero countdown`() {
+        val service = timetableEntry(serviceTripId = "now", departureSecs = NOW_SECS)
+
+        val visible = createVisibleServiceViewModels(listOf(service), isSelectedTime = false)
+
+        assertEquals(listOf("now"), visible.serviceTripIds())
+    }
+
+    @Test
+    fun `current time mode keeps visible ServiceViewModel for positive countdown`() {
+        val service = timetableEntry(serviceTripId = "future", departureSecs = NOW_SECS + 60)
+
+        val visible = createVisibleServiceViewModels(listOf(service), isSelectedTime = false)
+
+        assertEquals(listOf("future"), visible.serviceTripIds())
+    }
+
+    @Test
+    fun `current time mode does not create visible ServiceViewModel for cancelled service`() {
+        val service = timetableEntry(
+            serviceTripId = "cancelled",
+            departureSecs = NOW_SECS + 60,
+            isCancelled = true
+        )
+
+        val visible = createVisibleServiceViewModels(listOf(service), isSelectedTime = false)
+
+        assertEquals(emptyList<String>(), visible.serviceTripIds())
+    }
+
+    @Test
+    fun `selected time mode keeps negative countdown ServiceViewModel visible`() {
+        val service = timetableEntry(serviceTripId = "past", departureSecs = NOW_SECS - 60)
+
+        val visible = createVisibleServiceViewModels(listOf(service), isSelectedTime = true)
+
+        assertEquals(listOf("past"), visible.serviceTripIds())
+    }
+
+    @Test
+    fun `current time mode removes past and cancelled items while preserving remaining order`() {
+        val past = timetableEntry(serviceTripId = "past", departureSecs = NOW_SECS - 60)
+        val cancelled = timetableEntry(
+            serviceTripId = "cancelled",
+            departureSecs = NOW_SECS + 30,
+            isCancelled = true
+        )
+        val now = timetableEntry(serviceTripId = "now", departureSecs = NOW_SECS)
+        val future = timetableEntry(serviceTripId = "future", departureSecs = NOW_SECS + 60)
+
+        val visible = createVisibleServiceViewModels(
+            listOf(past, cancelled, now, future),
+            isSelectedTime = false
+        )
+
+        assertEquals(listOf("now", "future"), visible.serviceTripIds())
+    }
+
+    @Test
+    fun `selected time mode keeps same rows that previous behavior mapped`() {
+        val past = timetableEntry(serviceTripId = "past", departureSecs = NOW_SECS - 60)
+        val cancelled = timetableEntry(
+            serviceTripId = "cancelled",
+            departureSecs = NOW_SECS + 30,
+            isCancelled = true
+        )
+        val now = timetableEntry(serviceTripId = "now", departureSecs = NOW_SECS)
+        val future = timetableEntry(serviceTripId = "future", departureSecs = NOW_SECS + 60)
+
+        val visible = createVisibleServiceViewModels(
+            listOf(past, cancelled, now, future),
+            isSelectedTime = true
+        )
+
+        assertEquals(listOf("past", "cancelled", "now", "future"), visible.serviceTripIds())
+    }
+
+    @Test
+    fun `current time mode uses realtime vehicle departure for visible ServiceViewModel filtering`() {
+        val service = timetableEntry(
+            serviceTripId = "vehicle-past",
+            departureSecs = NOW_SECS + 600,
+            vehicleDepartureSecs = NOW_SECS - 60
+        )
+
+        val visible = createVisibleServiceViewModels(listOf(service), isSelectedTime = false)
+
+        assertEquals(emptyList<String>(), visible.serviceTripIds())
+    }
+
+    private fun createVisibleServiceViewModels(
+        services: List<TimetableEntry>,
+        isSelectedTime: Boolean
+    ): List<ServiceViewModel> {
+        return createVisibleServiceViewModels(
+            services = services,
+            currentTripId = "",
+            timeZone = DateTimeZone.UTC,
+            isSelectedTime = isSelectedTime,
+            nowInMillis = TimeUnit.SECONDS.toMillis(NOW_SECS),
+            serviceViewModelProvider = Provider { FakeServiceViewModel() },
+            timetableEntryChosen = PublishRelay.create()
+        )
+    }
+
+    private fun List<ServiceViewModel>.serviceTripIds(): List<String?> {
+        return map { it.service.serviceTripId }
+    }
+
+    private fun timetableEntry(
+        serviceTripId: String,
+        departureSecs: Long,
+        vehicleDepartureSecs: Long? = null,
+        isCancelled: Boolean = false
+    ): TimetableEntry {
+        return TimetableEntry().apply {
+            this.serviceTripId = serviceTripId
+            this.startTimeInSecs = departureSecs
+            this.realTimeDeparture = -1
+            this.isCancelled = isCancelled
+            this.realtimeVehicle = vehicleDepartureSecs?.let {
+                RealTimeVehicle().apply {
+                    arriveAtStartStopTime = it
+                    this.serviceTripId = serviceTripId
+                }
+            }
+        }
+    }
+
+    private class FakeServiceViewModel : ServiceViewModel() {
+        override val occupancyViewModel: OccupancyViewModel = mockk(relaxed = true)
+        override val serviceAlertViewModel: ServiceAlertViewModel = mockk(relaxed = true)
+        override val serviceNumber = MutableLiveData<String>()
+        override val secondaryText = MutableLiveData<String>()
+        override val secondaryTextColor = MutableLiveData<Int>()
+        override val tertiaryText = MutableLiveData<String>()
+        override val quaternaryText = MutableLiveData<String>()
+        override val countDownTimeText = MutableLiveData<String>()
+        override val countDownTimeTextColor = MutableLiveData<Int>()
+        override val alpha = MutableLiveData<Float>()
+        override val countDownTimeTextBack = MutableLiveData<Drawable>()
+        override val serviceColor = MutableLiveData<Int>()
+        override val showOccupancyInfo = MutableLiveData<Boolean>()
+        override val showBicycleAccessible = MutableLiveData<Boolean>()
+        override val isCurrentTrip = MutableLiveData<Boolean>()
+        override val wheelchairIcon = MutableLiveData<Drawable?>()
+        override val wheelchairTint = MutableLiveData<Int>()
+        override val wheelchairBackgroundTint = MutableLiveData<Drawable>()
+        override val modeInfo = MutableLiveData<ModeInfo>()
+        override val onItemClick = TapAction.create { service }
+        override val onAlertsClick = TapAction.create<List<RealtimeAlert>?> { null }
+        override lateinit var service: TimetableEntry
+        override lateinit var dateTimeZone: DateTimeZone
+
+        override fun getRealTimeDeparture(): Long {
+            return realTimeDeparture(service, service.realtimeVehicle)
+        }
+
+        override fun setService(
+            _currentTripId: String,
+            _service: TimetableEntry,
+            _dateTimeZone: DateTimeZone
+        ) {
+            service = _service
+            dateTimeZone = _dateTimeZone
+        }
+    }
+
+    private companion object {
+        const val NOW_SECS = 1_700_000_000L
+    }
+}


### PR DESCRIPTION
# Pull Request (PR) Checklist

Thank you for your contribution! Please confirm that you've checked all the boxes below before submitting your PR. Use `[x]` to check a box, e.g., `[x]`, and make sure there's no space around the brackets.

## PR Context

- **Type**: Bug Fix
- **Issue Link**: [Redmine Issue](https://redmine.buzzhives.com/issues/24554)
[Redmine Issue](https://redmine.buzzhives.com/issues/25966)
[Redmine Issue](https://redmine.buzzhives.com/issues/25964)
[Redmine Issue](https://redmine.buzzhives.com/issues/25631)
- **Risk Factor**: Medium - Touches map marker lifecycle, trip result rendering, timetable filtering, and polyline/memory paths; behavior changes around departed/cancelled services and marker caching need device validation. Also includes related fixes from #25966, #25964, and #25631 on the same branch.

## Changes

Addresses memory pressure / OOM and stability issues around map markers, trip results, and timetables across **tripgov5** and **tripkit-android-ui**, plus a few related UI fixes that landed on this branch.

**Memory / OOM / map performance (`[24554]`)**
- Added bounded marker bitmap descriptor caching, safer bitmap ownership/recycling, and in-flight icon request dedupe in `RemoteMarkerIconFetcher`
- Added lifecycle cleanup / dedup for segment markers and stale map markers in `TripResultMapContributor` and `TripKitMapFragment`
- Guarded scheduled-stop loading to reduce repeated DB/marker churn during viewport changes
- Merged contiguous route segments in `GetTripLine` / `TripLine` to reduce polyline memory
- Prevented OOM during route highlighting; reduced allocations in `TimeSpanUtils`; removed noisy zoom logging
- Excluded invalid zero vehicle UUIDs from waypoint / preview flows
- Lightened timetable/info-window overlay paths; added `TripGoMapMarkerDiag` for marker lifecycle diagnostics

**Trip result / preview stability (`[24554]`)**
- Preload `TripGroup` into segment list fragments for immediate render while keeping repository updates active (`TripSegmentListFragment`, `TripSegmentsViewModel`, `TripGroupsPagerAdapter`)
- Resolve trips by UUID, trip ID, and display-trip fallback in `TripPreviewPagerFragment` to avoid first-load blank states
- Reduced preview pager memory usage and guarded pager indices

**Timetable (`[24554]`)**
- Filter already-departed and cancelled services at the final `ServiceViewModel` list boundary for current-time loads (preserve selected-time behavior)
- Safely handle empty timetable results and clear obsolete subscriptions
- Added/updated `TimetableDepartedRealtimeFilterTest` coverage

**tripgov5-specific (`[24554]`)**
- Fixed `WelcomeBannerCard` resource crash
- Refresh results after DRT booking flow via `HomeNavigator`
- Related updates in `TripPreviewPagerListenerHomeImpl`

**Related fixes also on this branch**
- `[25966]` Fix map markers failing to render (dedupe persisted stop locations; retain Picasso targets until icon load completes)
- `[25966]` Use `serviceDirection` for service name when name and direction differ (`ServiceDetailViewModel`)
- `[25964]` Unified scrolling for alerts and service stops in service detail bottom sheet layouts (UI)
- `[25631]` Fix `isIncluded` on `TransportModeDetailsViewModel` so mode-related details show/hide correctly when toggled (tripgov5)

## Checklist for Reviewers

### Documentation and Code Quality
- [ ] **KDocs Documentation**: Are all changes, new functionalities, and classes documented with KDocs?
- [ ] **Architectural Patterns**: Is there consistent and proper use of architectural patterns (e.g., MVVM, MVP)?

### Testing and Reliability
- [ ] **Unit Testing**: Are there unit tests for all new functionalities and classes?
- [ ] **Emulator and Real Device Testing**: Has the application been tested on both emulators and real devices to ensure compatibility?

### Error Handling and Logging
- [ ] **Error Handling**: Are errors and exceptions caught and handled gracefully, ensuring the app remains stable?
- [ ] **Logging**: Is there proper logging in place for critical errors and information, aiding in debugging and monitoring?


## Testing Procedure
- 
-
-

## Work-in-Progress (WIP)
-
-

_Remember to keep this template updated based on the feedback and evolving project standards._